### PR TITLE
docs: restore original README Pages URL casing (capital Rex)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A clone of the Chrome offline dinosaur game, built with vanilla JavaScript and HTML5 Canvas.
 
-**Play it here:** https://snehiths19.github.io/chrome-offline-rex/
+**Play it here:** https://snehiths19.github.io/chrome-offline-Rex/
 
 ## Controls
 


### PR DESCRIPTION
The lowercase URL I changed it to returns 404. GitHub Pages path casing matches the repository name, which is chrome-offline-Rex.