### PR TITLE
Code-review suggestions + phase 1 juice (RNG spawn jitter)

### DIFF
--- a/docs/dev/plans/2026-04-22-juice-and-variable-obstacles.md
+++ b/docs/dev/plans/2026-04-22-juice-and-variable-obstacles.md
@@ -1,0 +1,197 @@
+# Juice Pass + Variable Obstacles
+
+**Date:** 2026-04-22
+**Status:** Planning — awaiting approval
+
+## Context
+
+The game currently feels mechanically and sensorially flat in two ways:
+
+1. **Obstacles are monotonous.** Every obstacle is the same 20×40 cactus sprite. Spacing follows a deterministic formula (`MAX_SPAWN_GAP - (speed - INITIAL_SPEED) × 100`, clamped to `MIN_SPAWN_GAP`), so at any given speed the gap is always identical. The rhythm is predictable and reads as "metronome."
+2. **No tactile feedback.** Jumping, landing, scoring milestones, and dying are all silent and un-particle'd. Death is a 12-frame canvas shake with no flash or sound.
+
+This plan addresses both: introduce obstacle variety + spacing jitter, then a juice pass (particles, synthesised SFX, death flash). Music is explicitly out of scope for v1 — procedurally-generated SFX via Web Audio API avoids adding asset files.
+
+---
+
+## Part A — Variable obstacles
+
+### Obstacle taxonomy
+
+Three ground-based types (no ducking mechanic required):
+
+| Type        | Width × Height | Unlock score | Weight (before cap) | Notes |
+|-------------|----------------|--------------|---------------------|-------|
+| `smallCactus` | 20 × 40 | 0 | 50 | current cactus — baseline |
+| `bigCactus`   | 28 × 55 | 100 | 30 | taller; tighter jump timing |
+| `cactusCluster` | 50 × 40 | 250 | 20 | 2–3 small cacti glued together; wider object, same height |
+
+Weights shift with score so later runs see more variety:
+- `score < 100`: only `smallCactus`
+- `100 ≤ score < 250`: 70% small, 30% big
+- `score ≥ 250`: 50 / 30 / 20 (small / big / cluster)
+
+Pick via `game.rng()` (seeded — see below) against cumulative weights.
+
+### Spacing jitter
+
+Replace the current deterministic gap threshold with a randomized range:
+
+```
+baseGap = clamp(MAX_SPAWN_GAP - (speed - INITIAL_SPEED) × SPAWN_GAP_SPEED_FACTOR,
+                MIN_SPAWN_GAP, MAX_SPAWN_GAP)
+actualGap = baseGap × (1 + rng.range(-0.25, 0.25))  // ±25% jitter
+```
+
+Store `nextSpawnAt` on `game` the moment an obstacle spawns, so the spawn decision becomes `game.lastObstacleX <= canvas.width - game.nextSpawnGap`. This keeps collision-safety guarantees (jitter range chosen so the smallest possible gap is still clearable by a standard jump).
+
+**Reachability check**: smallest jitter'd gap at cap speed = `MIN_SPAWN_GAP × 0.75 = 255px`. A full jump covers ~384px horizontally at cap speed (airtime ≈ 50 frames × 5px/frame + width). Comfortably clearable. Worth adding a unit test asserting this.
+
+### Seeded RNG
+
+Add a tiny mulberry32 PRNG (~10 LOC) on `game.rng`. Re-seeded in `resetGame()` from `Date.now()`. Enables:
+- Deterministic test fixtures.
+- Future "daily seed" feature without refactoring.
+
+### Sprite assets
+
+For v1, render `bigCactus` and `cactusCluster` from the existing `cactus.png` by drawing the sprite scaled / tiled, so no new asset files are required. If authored sprites show up later, swap via a small lookup table in `drawObstacles`.
+
+### Files touched (Part A)
+
+- `script.js`
+  - `GAME_CONFIG`: add `OBSTACLE_TYPES` table, `SPAWN_GAP_JITTER` (= 0.25).
+  - New helpers: `pickObstacleType(score, rng)`, `mulberry32(seed)`.
+  - `spawnObstacle()` now takes a type, sets width/height/drawMode accordingly.
+  - `drawObstacles()` branches on obstacle.type: `smallCactus` → unchanged; `bigCactus` → `drawImage` with scaled h×w; `cactusCluster` → two `drawImage` calls side by side.
+  - Game loop spawn block: switch to `game.nextSpawnGap` stored on reset.
+  - `resetGame()`: reseed `game.rng`, clear `game.nextSpawnGap`.
+
+- `tests/game.test.js`
+  - Weight-distribution test: 10k rolls at score 400 stay within ±3% of declared weights.
+  - Jitter-bounds test: sampled gaps always fall within `[baseGap × 0.75, baseGap × 1.25]`.
+  - Reachability test: smallest possible gap is >= max horizontal jump distance at cap speed.
+  - Update existing gap-enforcement test to accept the jittered range.
+
+---
+
+## Part B — Juice pass
+
+### B1. Particles (canvas-based, no deps)
+
+Add a tiny particle system: a pool of ~60 particle objects with `{ x, y, vx, vy, life, maxLife, color, size }`. Drawn as filled circles.
+
+**Emit points:**
+- **Jump takeoff** — 4–6 dust particles at dino's feet, low upward + sideways velocity. Grey/brown palette.
+- **Landing** — 8–10 particles on touchdown, stronger sideways spread. Only when landing at normal velocity (not death).
+- **Collision** — 20+ particles burst radially from collision point, red/orange palette.
+- **Speed trail** — at cap speed (or within 10% of it), one faint particle per frame trailing behind dino.
+
+**Respect reduced motion**: if `reducedMotion`, skip all emits (or emit half the count with longer lifetime, TBD — probably just skip).
+
+### B2. Sound effects (Web Audio synthesis, no asset files)
+
+Thin wrapper module at top of `script.js` (behind a `typeof window !== 'undefined' && window.AudioContext` guard):
+
+```js
+const audio = {
+  ctx: null,
+  ensure() { if (!this.ctx) this.ctx = new AudioContext(); return this.ctx; },
+  blip(freq, duration, type = 'sine', gain = 0.05) { ... },
+  jump()   { this.blip(400 + rand(-20, 20), 0.08, 'sine', 0.04); },
+  land()   { this.blip(120, 0.05, 'sine', 0.05); },
+  milestone() { this.blip(880, 0.1, 'triangle'); setTimeout(() => this.blip(1320, 0.1, 'triangle'), 80); },
+  death()  { /* downward freq sweep on sawtooth */ },
+};
+```
+
+**Browser autoplay policy**: `AudioContext` must be created after a user gesture. Initialise it on the first `handleAction()` call (any input unlocks audio). Before that, `audio.jump()` et al. no-op.
+
+**Mute control**: add a mute button in `index.html` (top-right corner of canvas wrapper). Persist `localStorage['dino-muted']`. Default off.
+
+### B3. Death flash + chromatic shift
+
+On collision:
+- Start a 6-frame white flash overlay (`fillStyle = 'rgba(255,255,255,alpha)'` full-canvas, alpha ramps 1 → 0).
+- Increase death shake amplitude for first 3 frames (already exists — bump `DEATH_SHAKE_AMPLITUDE` from 4 to 7 for those frames).
+- Cheap "chromatic aberration": draw `drawDino` three times offset by ±2px horizontally with red/blue tint via `globalCompositeOperation = 'screen'` — only on the first 3 post-death frames. Dropped if perf budget tight.
+
+### B4. Score milestone celebration
+
+At each level-up (existing "LEVEL X" flash), additionally:
+- Emit a 20-particle confetti-like burst from the score HUD position (gold palette).
+- Fire `audio.milestone()`.
+
+### B5. Reduced-motion consideration
+
+All Part B effects respect `reducedMotion`:
+- Particles: skipped entirely.
+- SFX: unaffected (sound is not motion).
+- Death flash: kept but capped at one frame, no chromatic aberration.
+- Milestone confetti: replaced with a simple text pop.
+
+### Files touched (Part B)
+
+- `script.js`
+  - New sections: `audio`, `particles` (pool + `emit(kind, x, y)` + `updateParticles()` + `drawParticles()`).
+  - Hook emits into `jump()`, landing branch of gameLoop, collision branch, milestone branch.
+  - Death flash state on `game`: `deathFlashFrames`.
+  - Call `audio.ensure()` in `handleAction()` to unlock audio.
+
+- `index.html`
+  - Add `<button id="mute-btn" aria-label="Mute sound">🔊</button>` (or SVG icon). Positioned absolute over the canvas top-right.
+
+- `style.css`
+  - Position + hover/focus states for `#mute-btn`.
+
+- `tests/game.test.js`
+  - Particle pool: emit/update/expire lifecycle test.
+  - Audio guard: `audio.jump()` with no AudioContext is a no-op and doesn't throw.
+  - Death flash lifecycle: 6 frames, counts down, zero when DEAD sub-state passes.
+
+---
+
+## Implementation phases
+
+Ship small, land each phase on its own PR. Each phase keeps tests passing.
+
+1. **RNG + spacing jitter** (~1 h). Minimal visual change; validates seeded RNG path + test updates.
+2. **Obstacle types + scaled rendering** (~2 h). First real "variety" moment.
+3. **Particle system + takeoff/landing emits** (~2 h).
+4. **Collision particles + death flash** (~1 h).
+5. **Web Audio SFX + mute button** (~2 h). Independent, could also be phase 3.
+6. **Milestone confetti + audio** (~45 min).
+7. **Polish pass**: adjust weights, jitter, particle counts, volumes from playtesting (~1 h).
+
+Total: ~10 hours. Phases 1 and 2 together deliver the variety the user noticed; phases 3–7 deliver juice.
+
+---
+
+## Open questions (for the user)
+
+1. **Web Audio SFX vs. sample files?** Synthesis means no asset downloads but the sounds are a bit chiptune. Sample files give nicer tones but add ~100 KB. I'd suggest synthesis for v1, revisit later.
+2. **Adaptive music**: still out of scope? The scope here is SFX only; music is a bigger lift.
+3. **Mute default**: off (sound on) or on (sound off)? Mobile users may prefer sound-off by default.
+4. **Ducking / pterodactyls**: explicitly *not* in this plan, per today's conversation. Flag if you want it folded in — would restructure Part A.
+
+---
+
+## Verification
+
+- `npm test` — all existing 23 tests + ~6 new tests pass.
+- Manual playtest checklist:
+  - [ ] Three obstacle types appear at their score thresholds.
+  - [ ] Spacing feels less metronomic; no unreachable gaps after 10 runs to score 1000+.
+  - [ ] Jump and land puff dust on every jump.
+  - [ ] Death produces a flash + particle burst.
+  - [ ] Milestone flash pops confetti and plays a ding.
+  - [ ] Mute button silences audio and persists across reload.
+  - [ ] With OS reduce-motion on: no particles, single-frame flash, SFX still plays.
+  - [ ] Audio stays silent until first user input (browser autoplay policy honoured).
+
+## Critical files
+
+- `/home/user/chrome-offline-Rex/script.js`
+- `/home/user/chrome-offline-Rex/index.html`
+- `/home/user/chrome-offline-Rex/style.css`
+- `/home/user/chrome-offline-Rex/tests/game.test.js`

--- a/script.js
+++ b/script.js
@@ -77,8 +77,9 @@ const GAME_CONFIG = Object.freeze({
   // --- Spawning ---
   GRACE_FRAMES:           240,    // ~4 s at 60 fps before first obstacle appears
   MAX_SPAWN_GAP:          600,    // gap (px) between obstacles at INITIAL_SPEED
-  MIN_SPAWN_GAP:          340,    // gap (px) at SPEED_CAP
+  MIN_SPAWN_GAP:          340,    // gap (px) at SPEED_CAP — tuned minimum that's still clearable
   SPAWN_GAP_SPEED_FACTOR: 100,    // gap shrinks by this much per +1 speed above INITIAL_SPEED
+  SPAWN_GAP_JITTER:         0.2,  // ±20% randomization applied on top of baseGap; floored at MIN_SPAWN_GAP
 
   // --- Obstacle sprite ---
   OBS_WIDTH:               20,
@@ -237,6 +238,30 @@ if (typeof setTimeout !== 'undefined' && !isNode) {
 
 // == SECTION 4: GAME STATE ==
 
+// mulberry32 — tiny seeded PRNG (~32-bit state). Swappable via `game.rng` so
+// tests can pin it to a deterministic sequence.
+function mulberry32(seed) {
+  let s = seed >>> 0;
+  return function () {
+    s = (s + 0x6d2b79f5) >>> 0;
+    let t = s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// Compute the gap (px) to the next obstacle, given current speed + an RNG.
+// Jitter is applied ±SPAWN_GAP_JITTER around baseGap, then floored at
+// MIN_SPAWN_GAP so the smallest possible gap is always clearable.
+function computeNextSpawnGap(rng, currentSpeed) {
+  const baseGap =
+    GAME_CONFIG.MAX_SPAWN_GAP -
+    (currentSpeed - GAME_CONFIG.INITIAL_SPEED) * GAME_CONFIG.SPAWN_GAP_SPEED_FACTOR;
+  const jitter = (rng() - 0.5) * 2 * GAME_CONFIG.SPAWN_GAP_JITTER; // range [-J, +J]
+  return Math.max(GAME_CONFIG.MIN_SPAWN_GAP, Math.round(baseGap * (1 + jitter)));
+}
+
 // All mutable game state lives on this object. Keeping it in one place prevents
 // stray top-level globals and makes resets + test inspection simpler.
 const game = {
@@ -244,6 +269,7 @@ const game = {
   obstacles:        [],
   currentSpeed:     GAME_CONFIG.INITIAL_SPEED,
   lastObstacleX:    -300,
+  nextSpawnGap:     GAME_CONFIG.MAX_SPAWN_GAP,
   graceFrames:      GAME_CONFIG.GRACE_FRAMES,
   animationFrameId: undefined,
   score:            0,
@@ -258,6 +284,7 @@ const game = {
   milestoneFrames:  0,
   newBestFrames:    0,
   newBestShown:     false,
+  rng:              mulberry32(Date.now() & 0xffffffff),
 };
 
 // == SECTION 5: RENDERING ==
@@ -518,6 +545,8 @@ function resetGame() {
   game.milestoneFrames = 0;
   game.newBestFrames = 0;
   game.newBestShown = false;
+  game.rng = mulberry32(Date.now() & 0xffffffff);
+  game.nextSpawnGap = computeNextSpawnGap(game.rng, game.currentSpeed);
   initClouds();
   announce('New game. Press space or tap to jump.');
 }
@@ -596,14 +625,12 @@ function gameLoop() {
   drawClouds();
   updateObstacles();
 
-  // Obstacle spawning — gap compresses linearly with speed.
-  const spawnGap = Math.max(
-    GAME_CONFIG.MIN_SPAWN_GAP,
-    Math.round(GAME_CONFIG.MAX_SPAWN_GAP - (game.currentSpeed - GAME_CONFIG.INITIAL_SPEED) * GAME_CONFIG.SPAWN_GAP_SPEED_FACTOR)
-  );
-  if (game.lastObstacleX <= canvas.width - spawnGap) {
+  // Obstacle spawning — gap is precomputed per-obstacle with ±SPAWN_GAP_JITTER
+  // so spacing doesn't feel metronomic. See computeNextSpawnGap().
+  if (game.lastObstacleX <= canvas.width - game.nextSpawnGap) {
     spawnObstacle();
     game.lastObstacleX = canvas.width;
+    game.nextSpawnGap = computeNextSpawnGap(game.rng, game.currentSpeed);
   }
 
   drawObstacles();
@@ -681,4 +708,6 @@ if (typeof process !== 'undefined' && process.versions && process.versions.node)
   global.resetGame = resetGame;
   global.gameLoop = gameLoop;
   global.drawGameOverScreen = drawGameOverScreen;
+  global.mulberry32 = mulberry32;
+  global.computeNextSpawnGap = computeNextSpawnGap;
 }

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -227,24 +227,72 @@ describe('Obstacle Gap Enforcement', () => {
     resetGame();
     game.graceFrames = 0;
     game.state = STATE.RUNNING;
+    // Pin the RNG to the middle of the jitter range so nextSpawnGap is deterministic.
+    game.rng = () => 0.5;
+    game.nextSpawnGap = 600; // base gap at speed 2, zero jitter
 
-    // Frame 1: lastObstacleX=-300 ≤ canvas.width-spawnGap(600) → first spawn
+    // Frame 1: lastObstacleX=-300 ≤ canvas.width-600 → first spawn
     gameLoop();
     cancelAnimationFrame(game.animationFrameId);
     assertEquals(game.obstacles.length, 1, 'Should have 1 obstacle after first gameLoop frame');
 
-    // Frame 2: obstacle just spawned at x=600; dynamic gap is 600px at speed=2
+    // After spawn, nextSpawnGap was recomputed at zero-jitter → 600 at speed 2
+    assertEquals(game.nextSpawnGap, 600, 'Next gap should be baseGap 600 at speed 2 with zero jitter');
+
+    // Frame 2: obstacle at ~598; 598 > 600 - 600 = 0 — not yet
     gameLoop();
     cancelAnimationFrame(game.animationFrameId);
-    assertEquals(game.obstacles.length, 1, 'Should still be 1 obstacle — dynamic gap (600px at speed 2) not met');
+    assertEquals(game.obstacles.length, 1, 'Should still be 1 obstacle — 600px gap not met');
 
-    // Force obstacle just past the dynamic threshold
+    // Force obstacle just past the threshold
     game.obstacles[0].x = canvas.width - 601;
     game.lastObstacleX = game.obstacles[0].x;
 
     gameLoop();
     cancelAnimationFrame(game.animationFrameId);
-    assertEquals(game.obstacles.length, 2, 'Should now be 2 obstacles — dynamic gap threshold met');
+    assertEquals(game.obstacles.length, 2, 'Should now be 2 obstacles — gap threshold met');
+  });
+});
+
+describe('Spawn Gap Jitter', () => {
+  it('computeNextSpawnGap stays within [MIN_SPAWN_GAP, baseGap * (1 + JITTER)]', () => {
+    const speeds = [GAME_CONFIG.INITIAL_SPEED, 3.0, GAME_CONFIG.SPEED_CAP];
+    speeds.forEach(speed => {
+      const baseGap = Math.max(
+        GAME_CONFIG.MIN_SPAWN_GAP,
+        GAME_CONFIG.MAX_SPAWN_GAP - (speed - GAME_CONFIG.INITIAL_SPEED) * GAME_CONFIG.SPAWN_GAP_SPEED_FACTOR
+      );
+      const upperBound = Math.round(baseGap * (1 + GAME_CONFIG.SPAWN_GAP_JITTER));
+      const rng = mulberry32(12345);
+      for (let i = 0; i < 500; i++) {
+        const gap = computeNextSpawnGap(rng, speed);
+        assert(
+          gap >= GAME_CONFIG.MIN_SPAWN_GAP && gap <= upperBound,
+          `At speed ${speed}, gap ${gap} should be in [${GAME_CONFIG.MIN_SPAWN_GAP}, ${upperBound}]`
+        );
+      }
+    });
+  });
+
+  it('produces different gaps across spawns (breaks the metronome)', () => {
+    const rng = mulberry32(7);
+    const gaps = new Set();
+    for (let i = 0; i < 50; i++) gaps.add(computeNextSpawnGap(rng, 2.0));
+    assert(gaps.size >= 5, `Expected gap variety; got ${gaps.size} distinct values across 50 draws`);
+  });
+
+  it('smallest achievable gap is still at least MIN_SPAWN_GAP (always clearable)', () => {
+    // Exhaustively test by forcing rng to 0 (maximum negative jitter).
+    const worstCaseRng = () => 0;
+    const gap = computeNextSpawnGap(worstCaseRng, GAME_CONFIG.SPEED_CAP);
+    assert(gap >= GAME_CONFIG.MIN_SPAWN_GAP,
+      `At max negative jitter + cap speed, gap ${gap} must be >= MIN_SPAWN_GAP ${GAME_CONFIG.MIN_SPAWN_GAP}`);
+  });
+
+  it('mulberry32 is deterministic given same seed', () => {
+    const a = mulberry32(42);
+    const b = mulberry32(42);
+    for (let i = 0; i < 10; i++) assertEquals(a(), b(), 'Same seed should produce same sequence');
   });
 });
 


### PR DESCRIPTION
Four commits, rolled up so you can eyeball the whole thing live after deploy.

## 1. `refactor: apply code-review suggestions` (0f64b6d)

- **State encapsulation**: 19 module-level `let`s → single `game` object.
- **Magic numbers**: cloud/star rendering, death shake, milestone/new-best durations, score HUD offsets, asset timeout — all moved to `GAME_CONFIG` with inline comments for the non-obvious physics constants.
- **Accessibility**: `role="application"` + `aria-live` region announcing new game / game-start / game-over (score + high score) / new-best; `prefers-reduced-motion` disables cloud movement, star twinkle, and day/night colour interpolation; `:active` + `:focus-visible` on the mobile jump button; focus outline on the canvas.
- **Reliability**: drawing falls back to rectangles when a sprite fails to load; 5 s browser-only asset-load timeout as a safety net.
- **Tests**: migrated the 15 existing tests to the `game.*` API and added 4 state-transition tests; previously-broken async jump test is now deterministic and synchronous.
- **Tooling**: `package.json`, ESLint flat config, Prettier config, `.gitignore`. Split CI: `pages.yml` now gates deploy on `node tests/game.test.js`, and new `ci.yml` runs tests on all branches / PRs.
- **Docs**: moved internal planning docs from `docs/superpowers/` → `docs/dev/`.

## 2. `docs: restore README Pages URL casing` (a6516ec)

I accidentally lowercased the Pages link during the refactor and it 404'd. Restored to `chrome-offline-Rex`.

## 3. `docs(dev): plan for juice pass + variable obstacles` (0aac54f)

Written plan in `docs/dev/plans/`. Not yet implemented.

## 4. `feat(dino): phase 1 — seeded RNG + spawn gap jitter` (4d4ecde)

Breaks the metronomic spawn rhythm:

- `mulberry32` PRNG on `game.rng`, reseeded each `resetGame()` from `Date.now()`.
- `SPAWN_GAP_JITTER = 0.2` → ±20% randomization on top of the speed-based `baseGap`, floored at `MIN_SPAWN_GAP` so the smallest possible gap is still always clearable.
- `game.nextSpawnGap` precomputed per spawn so the jitter is stable per-obstacle.
- 4 new tests (bounds, variety, always-clearable floor, PRNG determinism).

## Test plan

- [x] `node tests/game.test.js` — 27/27 passing locally.
- [ ] CI `test` job passes (gates deploy).
- [ ] After deploy, hit https://snehiths19.github.io/chrome-offline-Rex/ and play 3+ runs:
  - [ ] Obstacles visibly arrive at inconsistent intervals (not metronomic).
  - [ ] Every gap still feels jumpable at cap speed (no unclearable patterns).
  - [ ] Game-over + new-best still work, screen still shakes on death.
  - [ ] `GET READY` countdown still fires on fresh start.
- [ ] Toggle OS reduce-motion on → clouds/stars freeze, gameplay still runs.
- [ ] Screen reader test: new-game, game-over, new-best are announced.
- [ ] Mobile jump button responds with `:active` depression.

## What's NOT in this PR

Phases 2–7 of the juice plan (variable obstacle types, particles, Web Audio SFX, death flash, milestone confetti, polish). Those land after we're happy with phase 1.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsMJsjjBrWUbWgC7c7tWrB)_