### PR TITLE
Chrome-T-Rex speed + variable obstacle types (phase 2)

### DIFF
--- a/script.js
+++ b/script.js
@@ -61,9 +61,9 @@ const GAME_CONFIG = Object.freeze({
   // --- Physics ---
   JUMP_POWER:              -12,   // negative = upward impulse applied on jump
   GRAVITY:                  0.48, // added to velocityY each frame while airborne
-  INITIAL_SPEED:            2.0,  // obstacle scroll speed at score 0
-  SPEED_CAP:                5.0,  // max scroll speed; plateau hit around score 1000
-  SPEED_INCREMENT:          0.3,  // speed added per level
+  INITIAL_SPEED:            6.0,  // obstacle scroll speed at score 0 (matches Chrome T-Rex)
+  SPEED_CAP:               13.0,  // max scroll speed (matches Chrome T-Rex)
+  SPEED_INCREMENT:          1.0,  // speed added per level — 7 levels to cap
   SCORE_PER_LEVEL:        100,    // score points per level-up
   SCORE_INCREMENT:          0.1,  // score added per frame while RUNNING
 
@@ -78,12 +78,22 @@ const GAME_CONFIG = Object.freeze({
   GRACE_FRAMES:           240,    // ~4 s at 60 fps before first obstacle appears
   MAX_SPAWN_GAP:          600,    // gap (px) between obstacles at INITIAL_SPEED
   MIN_SPAWN_GAP:          340,    // gap (px) at SPEED_CAP — tuned minimum that's still clearable
-  SPAWN_GAP_SPEED_FACTOR: 100,    // gap shrinks by this much per +1 speed above INITIAL_SPEED
-  SPAWN_GAP_JITTER:         0.2,  // ±20% randomization applied on top of baseGap; floored at MIN_SPAWN_GAP
+  SPAWN_GAP_SPEED_FACTOR:  50,    // gap shrinks by this much per +1 speed above INITIAL_SPEED
+  SPAWN_GAP_JITTER:         0.3,  // ±30% randomization; floored at MIN_SPAWN_GAP
 
-  // --- Obstacle sprite ---
+  // --- Obstacle sprite (small cactus — baseline) ---
   OBS_WIDTH:               20,
   OBS_HEIGHT:              40,
+
+  // --- Obstacle types ---
+  // Each type unlocks at a score threshold and contributes its `weight` to the
+  // weighted random pick once unlocked. `render` controls how drawObstacles()
+  // paints it from the single cactus sprite.
+  OBSTACLE_TYPES: Object.freeze([
+    Object.freeze({ id: 'small',   width: 20, height: 40, unlockScore:   0, weight: 50, render: 'single' }),
+    Object.freeze({ id: 'big',     width: 30, height: 55, unlockScore: 100, weight: 30, render: 'single' }),
+    Object.freeze({ id: 'cluster', width: 50, height: 40, unlockScore: 250, weight: 20, render: 'double' }),
+  ]),
 
   // --- Dino sprite ---
   DINO_X:                  50,
@@ -262,6 +272,20 @@ function computeNextSpawnGap(rng, currentSpeed) {
   return Math.max(GAME_CONFIG.MIN_SPAWN_GAP, Math.round(baseGap * (1 + jitter)));
 }
 
+// Pick an obstacle type weighted by score-tier eligibility. Types with
+// unlockScore > score are excluded; among the rest, each contributes its
+// `weight` to a weighted random draw.
+function pickObstacleType(rng, score) {
+  const eligible = GAME_CONFIG.OBSTACLE_TYPES.filter(t => score >= t.unlockScore);
+  const totalWeight = eligible.reduce((sum, t) => sum + t.weight, 0);
+  let roll = rng() * totalWeight;
+  for (const t of eligible) {
+    roll -= t.weight;
+    if (roll <= 0) return t;
+  }
+  return eligible[eligible.length - 1]; // rounding guard
+}
+
 // All mutable game state lives on this object. Keeping it in one place prevents
 // stray top-level globals and makes resets + test inspection simpler.
 const game = {
@@ -357,11 +381,19 @@ function drawGround() {
 
 function drawObstacles() {
   game.obstacles.forEach(obstacle => {
-    if (imageReady(obstacleImage)) {
-      ctx.drawImage(obstacleImage, obstacle.x, obstacle.y, obstacle.width, obstacle.height);
-    } else {
+    if (!imageReady(obstacleImage)) {
       ctx.fillStyle = '#2d7a2d';
       ctx.fillRect(obstacle.x, obstacle.y, obstacle.width, obstacle.height);
+      return;
+    }
+    if (obstacle.render === 'double') {
+      // Cluster: draw two small cacti side by side to fill the 50-wide box.
+      const half = obstacle.width / 2;
+      ctx.drawImage(obstacleImage, obstacle.x,         obstacle.y, half, obstacle.height);
+      ctx.drawImage(obstacleImage, obstacle.x + half,  obstacle.y, half, obstacle.height);
+    } else {
+      // Single (small, big): scale the sprite to the type's width/height.
+      ctx.drawImage(obstacleImage, obstacle.x, obstacle.y, obstacle.width, obstacle.height);
     }
   });
 }
@@ -450,12 +482,16 @@ function drawNewBestBadge() {
 
 // == SECTION 6: PHYSICS & GAME LOGIC ==
 
-function spawnObstacle() {
+function spawnObstacle(type) {
+  // Default to a tier-appropriate random pick; tests may pass a specific type.
+  const t = type || pickObstacleType(game.rng, game.score);
   game.obstacles.push({
     x: canvas.width,
-    y: canvas.height - GAME_CONFIG.OBS_HEIGHT,
-    width: GAME_CONFIG.OBS_WIDTH,
-    height: GAME_CONFIG.OBS_HEIGHT,
+    y: canvas.height - t.height,
+    width: t.width,
+    height: t.height,
+    type: t.id,
+    render: t.render,
   });
 }
 
@@ -710,4 +746,5 @@ if (typeof process !== 'undefined' && process.versions && process.versions.node)
   global.drawGameOverScreen = drawGameOverScreen;
   global.mulberry32 = mulberry32;
   global.computeNextSpawnGap = computeNextSpawnGap;
+  global.pickObstacleType = pickObstacleType;
 }

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -229,17 +229,17 @@ describe('Obstacle Gap Enforcement', () => {
     game.state = STATE.RUNNING;
     // Pin the RNG to the middle of the jitter range so nextSpawnGap is deterministic.
     game.rng = () => 0.5;
-    game.nextSpawnGap = 600; // base gap at speed 2, zero jitter
+    game.nextSpawnGap = 600; // base gap at INITIAL_SPEED, zero jitter
 
     // Frame 1: lastObstacleX=-300 ≤ canvas.width-600 → first spawn
     gameLoop();
     cancelAnimationFrame(game.animationFrameId);
     assertEquals(game.obstacles.length, 1, 'Should have 1 obstacle after first gameLoop frame');
 
-    // After spawn, nextSpawnGap was recomputed at zero-jitter → 600 at speed 2
-    assertEquals(game.nextSpawnGap, 600, 'Next gap should be baseGap 600 at speed 2 with zero jitter');
+    // After spawn, nextSpawnGap was recomputed at zero-jitter → 600 at INITIAL_SPEED
+    assertEquals(game.nextSpawnGap, 600, 'Next gap should be baseGap 600 at INITIAL_SPEED with zero jitter');
 
-    // Frame 2: obstacle at ~598; 598 > 600 - 600 = 0 — not yet
+    // Frame 2: obstacle hasn't drifted 600 yet — not a spawn frame.
     gameLoop();
     cancelAnimationFrame(game.animationFrameId);
     assertEquals(game.obstacles.length, 1, 'Should still be 1 obstacle — 600px gap not met');
@@ -296,8 +296,64 @@ describe('Spawn Gap Jitter', () => {
   });
 });
 
+describe('Obstacle Types', () => {
+  it('only returns small cactus when score < 100', () => {
+    const rng = mulberry32(1);
+    for (let i = 0; i < 200; i++) {
+      const t = pickObstacleType(rng, 50);
+      assertEquals(t.id, 'small', `At score 50 expected small, got ${t.id}`);
+    }
+  });
+
+  it('can return big cactus at score 100+ but never cluster before 250', () => {
+    const rng = mulberry32(2);
+    const seen = new Set();
+    for (let i = 0; i < 500; i++) seen.add(pickObstacleType(rng, 150).id);
+    assert(seen.has('small') && seen.has('big'), `Expected small+big at score 150, saw ${[...seen]}`);
+    assert(!seen.has('cluster'), `Cluster should not appear before score 250, saw ${[...seen]}`);
+  });
+
+  it('can return all three types at score 250+', () => {
+    const rng = mulberry32(3);
+    const seen = new Set();
+    for (let i = 0; i < 2000; i++) seen.add(pickObstacleType(rng, 300).id);
+    assert(seen.has('small') && seen.has('big') && seen.has('cluster'),
+      `Expected all 3 types at score 300, saw ${[...seen]}`);
+  });
+
+  it('weighted distribution at score 300 is within 5% of declared weights', () => {
+    const rng = mulberry32(4);
+    const counts = { small: 0, big: 0, cluster: 0 };
+    const total = 20000;
+    for (let i = 0; i < total; i++) counts[pickObstacleType(rng, 300).id]++;
+    const expected = { small: 0.5, big: 0.3, cluster: 0.2 };
+    Object.keys(expected).forEach(id => {
+      const observed = counts[id] / total;
+      assert(Math.abs(observed - expected[id]) < 0.05,
+        `${id}: expected ~${expected[id]}, got ${observed.toFixed(3)}`);
+    });
+  });
+
+  it('spawnObstacle(type) respects the given type dimensions', () => {
+    resetGame();
+    const big = GAME_CONFIG.OBSTACLE_TYPES.find(t => t.id === 'big');
+    spawnObstacle(big);
+    assertEquals(game.obstacles[0].width, big.width, 'Big cactus width');
+    assertEquals(game.obstacles[0].height, big.height, 'Big cactus height');
+    assertEquals(game.obstacles[0].type, 'big', 'Obstacle should carry its type id');
+  });
+
+  it('spawnObstacle() with no arg picks a score-appropriate type via rng', () => {
+    resetGame();
+    game.rng = () => 0.99; // nudges weighted pick toward last eligible option
+    game.score = 0; // only small is eligible
+    spawnObstacle();
+    assertEquals(game.obstacles[0].type, 'small', 'At score 0 only small is eligible');
+  });
+});
+
 describe('Difficulty Curve', () => {
-  it('should cap currentSpeed at 5 regardless of score', () => {
+  it('should cap currentSpeed at SPEED_CAP regardless of score', () => {
     resetGame();
     game.state = STATE.RUNNING;
     game.graceFrames = 0;
@@ -306,7 +362,8 @@ describe('Difficulty Curve', () => {
     gameLoop();
     cancelAnimationFrame(game.animationFrameId);
 
-    assertEquals(game.currentSpeed, 5, `currentSpeed at score 2000 should be 5, got ${game.currentSpeed}`);
+    assertEquals(game.currentSpeed, GAME_CONFIG.SPEED_CAP,
+      `currentSpeed at score 2000 should equal SPEED_CAP (${GAME_CONFIG.SPEED_CAP}), got ${game.currentSpeed}`);
   });
 
   it('should not set a .speed property on spawned obstacles', () => {


### PR DESCRIPTION
Addresses two pieces of feedback from PR #9: the game feels too slow (so the spacing jitter from phase 1 was invisible) and obstacles all look the same.

## Speed: now matches Chrome's original T-Rex

Pulled values from the Chromium source (`chrome/browser/resources/dino/trex.js` — `config.SPEED`, `config.MAX_SPEED`, `config.ACCELERATION`):

| | Before | After |
|---|---|---|
| `INITIAL_SPEED` | 2.0 | **6.0** |
| `SPEED_CAP` | 5.0 | **13.0** |
| `SPEED_INCREMENT` (per 100-point level) | 0.3 | **1.0** |
| `SPAWN_GAP_SPEED_FACTOR` | 100 | **50** |
| `SPAWN_GAP_JITTER` | 0.2 | **0.3** |

The factor + jitter bumps matter because at `INITIAL_SPEED=2`, ±20% of the 600-px gap was ~0.5 s of variance — below the just-noticeable threshold. At `INITIAL_SPEED=6` with ±30%, the variance is visible across back-to-back obstacles. The factor drop spreads the gap compression across most of the 6→13 speed range instead of flatlining at level 3.

Every gap is still floored at `MIN_SPAWN_GAP=340`, which was tuned to be clearable; jump physics are unchanged (peak ≈144 px, airtime ≈50 frames = 300 px horizontal at start, 650 px at cap).

## Obstacle variety (Phase 2 of the juice plan)

Three types with score-gated unlocks:

| Type | W×H | Unlock | Weight | Render |
|---|---|---|---|---|
| `small` | 20×40 | 0 | 50 | single cactus (same as before) |
| `big` | 30×55 | 100 | 30 | single cactus, scaled larger |
| `cluster` | 50×40 | 250 | 20 | two half-width cacti side-by-side |

- Weighted pick on every spawn via `game.rng`.
- Obstacle carries `.type` + `.render`; collision hitbox scales automatically from the typed width/height.
- All rendering paths still have the green-rectangle fallback if `cactus.png` fails to load.

## Test plan

- [x] `node tests/game.test.js` — 33/33 passing locally (6 new: type-tier eligibility, weight distribution within 5% over 20k rolls, spawn dimensions, RNG-driven auto-pick).
- [ ] CI `test` job passes.
- [ ] Play 3+ runs after deploy at https://snehiths19.github.io/chrome-offline-Rex/:
  - [ ] Start speed feels like the original Chrome T-Rex (not sluggish).
  - [ ] Variable obstacle sizes visible immediately once you clear ~100 points.
  - [ ] Clusters appear around score 250+.
  - [ ] Spacing between obstacles noticeably varies run-to-run (no metronome feel).
  - [ ] Every obstacle is still clearable — no "impossible" patterns.
  - [ ] Game over + high score + new-best flow still work.

## Out of scope (future PRs)

Phases 3–7 of the juice plan: particles, Web Audio SFX, death flash, milestone confetti, polish.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsMJsjjBrWUbWgC7c7tWrB)_