### PR TITLE
Cache-bust script tag per deploy + expose debug globals

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -36,6 +36,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Cache-bust script URL with commit SHA
+        run: sed -i "s/__VERSION__/${GITHUB_SHA::7}/g" index.html
+
       - uses: actions/configure-pages@v5
 
       - uses: actions/upload-pages-artifact@v3

--- a/index.html
+++ b/index.html
@@ -12,6 +12,6 @@
     <button id="jump-btn" aria-label="Jump">TAP TO JUMP</button>
     <div id="a11y-live" class="sr-only" aria-live="polite" aria-atomic="true"></div>
   </div>
-  <script src="script.js"></script>
+  <script src="script.js?v=__VERSION__"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -311,6 +311,16 @@ const game = {
   rng:              mulberry32(Date.now() & 0xffffffff),
 };
 
+// In the browser, expose the game state + config on `window` so you can
+// sanity-check live values from DevTools console (e.g. `game.currentSpeed`,
+// `GAME_CONFIG.INITIAL_SPEED`). Skipped in Node — tests already get these
+// via the test-exposure block at the bottom of the file.
+if (typeof window !== 'undefined' && typeof process === 'undefined') {
+  window.game = game;
+  window.GAME_CONFIG = GAME_CONFIG;
+  window.STATE = STATE;
+}
+
 // == SECTION 5: RENDERING ==
 
 function getBackgroundColor(s) {


### PR DESCRIPTION
Browser cache was masking the speed change in PR #10 — Pages serves `script.js` with a 10-min `max-age` and our HTML had no version on the script tag, so browsers happily reused the old file.

## Changes

### 1. Per-deploy cache-bust

- `index.html` now: `<script src="script.js?v=__VERSION__"></script>`
- New sed step in `pages.yml` deploy job replaces `__VERSION__` with `${GITHUB_SHA::7}` before uploading the Pages artifact.
- Every push to `initial-chrome-dino-game` → fresh URL → forced refetch. No more "the deploy worked but my browser is showing the old version."
- Local dev / direct file open still works — `script.js?v=__VERSION__` is just a query string the server ignores.

### 2. DevTools-friendly globals

In the browser, `window.game`, `window.GAME_CONFIG`, and `window.STATE` are now exposed so you can sanity-check live values from F12 console:

```js
game.currentSpeed          // current px/frame
GAME_CONFIG.INITIAL_SPEED  // should be 6
game.obstacles.map(o => o.type)  // ['small'] / ['big', 'cluster'] / etc.
game.score
```

Gated on `typeof process === 'undefined'` so Node tests aren't affected.

## Test plan

- [x] `node tests/game.test.js` — 33/33 still passing.
- [x] Verified `sed "s/__VERSION__/${GITHUB_SHA::7}/g"` produces `script.js?v=abc1234` locally.
- [ ] CI test job passes.
- [ ] After deploy: hard refresh once, then never again — script tag URL changes per commit.
- [ ] In DevTools console: `game.currentSpeed` returns `6` (idle) ramping up to `13`.
- [ ] In DevTools console: `GAME_CONFIG.OBSTACLE_TYPES.map(t => t.id)` returns `['small','big','cluster']`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsMJsjjBrWUbWgC7c7tWrB)_