### PR TITLE
Mode toggle: Classic ⟷ Updated

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 </head>
 <body>
   <div id="game-wrapper" role="application" aria-label="Chrome dino game">
+    <button id="mode-btn" type="button" aria-pressed="true" aria-label="Mode: Updated. Switch to Classic.">Updated</button>
     <canvas id="gameCanvas" width="600" height="200" aria-label="Dino running game. Press space to jump."></canvas>
     <button id="jump-btn" aria-label="Jump">TAP TO JUMP</button>
     <div id="a11y-live" class="sr-only" aria-live="polite" aria-atomic="true"></div>

--- a/script.js
+++ b/script.js
@@ -36,7 +36,12 @@ if (typeof process !== 'undefined' && process.versions && process.versions.node)
           addEventListener: () => {},
         };
       }
-      return { addEventListener: () => {}, textContent: '' };
+      return {
+        addEventListener: () => {},
+        setAttribute: () => {},
+        dataset: {},
+        textContent: '',
+      };
     },
     addEventListener: () => {},
   };
@@ -263,19 +268,25 @@ function mulberry32(seed) {
 
 // Compute the gap (px) to the next obstacle, given current speed + an RNG.
 // Jitter is applied ±SPAWN_GAP_JITTER around baseGap, then floored at
-// MIN_SPAWN_GAP so the smallest possible gap is always clearable.
-function computeNextSpawnGap(rng, currentSpeed) {
+// MIN_SPAWN_GAP so the smallest possible gap is always clearable. In classic
+// mode, jitter is skipped — gaps are deterministic.
+function computeNextSpawnGap(rng, currentSpeed, mode) {
   const baseGap =
     GAME_CONFIG.MAX_SPAWN_GAP -
     (currentSpeed - GAME_CONFIG.INITIAL_SPEED) * GAME_CONFIG.SPAWN_GAP_SPEED_FACTOR;
+  if (mode === 'classic') {
+    return Math.max(GAME_CONFIG.MIN_SPAWN_GAP, Math.round(baseGap));
+  }
   const jitter = (rng() - 0.5) * 2 * GAME_CONFIG.SPAWN_GAP_JITTER; // range [-J, +J]
   return Math.max(GAME_CONFIG.MIN_SPAWN_GAP, Math.round(baseGap * (1 + jitter)));
 }
 
 // Pick an obstacle type weighted by score-tier eligibility. Types with
 // unlockScore > score are excluded; among the rest, each contributes its
-// `weight` to a weighted random draw.
-function pickObstacleType(rng, score) {
+// `weight` to a weighted random draw. In classic mode, only the small cactus
+// is ever returned — matches the original Chrome T-Rex's spartan look.
+function pickObstacleType(rng, score, mode) {
+  if (mode === 'classic') return GAME_CONFIG.OBSTACLE_TYPES[0]; // small cactus
   const eligible = GAME_CONFIG.OBSTACLE_TYPES.filter(t => score >= t.unlockScore);
   const totalWeight = eligible.reduce((sum, t) => sum + t.weight, 0);
   let roll = rng() * totalWeight;
@@ -284,6 +295,15 @@ function pickObstacleType(rng, score) {
     if (roll <= 0) return t;
   }
   return eligible[eligible.length - 1]; // rounding guard
+}
+
+const MODES = Object.freeze({ CLASSIC: 'classic', UPDATED: 'updated' });
+
+// Read the saved mode (defaults to 'updated' for first-time players). Persists
+// across reload so the user's preference is remembered.
+function loadMode() {
+  const stored = localStorage.getItem('dino-mode');
+  return stored === MODES.CLASSIC ? MODES.CLASSIC : MODES.UPDATED;
 }
 
 // All mutable game state lives on this object. Keeping it in one place prevents
@@ -309,7 +329,18 @@ const game = {
   newBestFrames:    0,
   newBestShown:     false,
   rng:              mulberry32(Date.now() & 0xffffffff),
+  mode:             loadMode(),
 };
+
+function setMode(newMode) {
+  game.mode = newMode === MODES.CLASSIC ? MODES.CLASSIC : MODES.UPDATED;
+  localStorage.setItem('dino-mode', game.mode);
+  refreshModeButtonLabel();
+  // Restart the run cleanly so the new mode's spawn rules take effect immediately.
+  cancelAnimationFrame(game.animationFrameId);
+  resetGame();
+  gameLoop();
+}
 
 // == SECTION 5: RENDERING ==
 
@@ -560,6 +591,26 @@ if (jumpBtn) {
   jumpBtn.addEventListener('click', handleAction);
 }
 
+const modeBtn = document.getElementById('mode-btn');
+function refreshModeButtonLabel() {
+  if (!modeBtn) return;
+  const isClassic = game.mode === MODES.CLASSIC;
+  modeBtn.textContent = isClassic ? 'Classic' : 'Updated';
+  modeBtn.dataset.mode = game.mode;
+  modeBtn.setAttribute('aria-pressed', String(!isClassic));
+  modeBtn.setAttribute(
+    'aria-label',
+    isClassic ? 'Mode: Classic. Switch to Updated.' : 'Mode: Updated. Switch to Classic.'
+  );
+}
+if (modeBtn) {
+  modeBtn.addEventListener('click', () => {
+    setMode(game.mode === MODES.CLASSIC ? MODES.UPDATED : MODES.CLASSIC);
+    announce(game.mode === MODES.CLASSIC ? 'Classic mode' : 'Updated mode');
+  });
+  refreshModeButtonLabel();
+}
+
 // == SECTION 8: GAME LOOP ==
 
 function resetGame() {
@@ -582,7 +633,7 @@ function resetGame() {
   game.newBestFrames = 0;
   game.newBestShown = false;
   game.rng = mulberry32(Date.now() & 0xffffffff);
-  game.nextSpawnGap = computeNextSpawnGap(game.rng, game.currentSpeed);
+  game.nextSpawnGap = computeNextSpawnGap(game.rng, game.currentSpeed, game.mode);
   initClouds();
   announce('New game. Press space or tap to jump.');
 }
@@ -661,12 +712,13 @@ function gameLoop() {
   drawClouds();
   updateObstacles();
 
-  // Obstacle spawning — gap is precomputed per-obstacle with ±SPAWN_GAP_JITTER
-  // so spacing doesn't feel metronomic. See computeNextSpawnGap().
+  // Obstacle spawning — in updated mode the gap is precomputed per-obstacle
+  // with ±SPAWN_GAP_JITTER so spacing doesn't feel metronomic; in classic mode
+  // it's deterministic. See computeNextSpawnGap() / pickObstacleType().
   if (game.lastObstacleX <= canvas.width - game.nextSpawnGap) {
-    spawnObstacle();
+    spawnObstacle(pickObstacleType(game.rng, game.score, game.mode));
     game.lastObstacleX = canvas.width;
-    game.nextSpawnGap = computeNextSpawnGap(game.rng, game.currentSpeed);
+    game.nextSpawnGap = computeNextSpawnGap(game.rng, game.currentSpeed, game.mode);
   }
 
   drawObstacles();
@@ -747,4 +799,7 @@ if (typeof process !== 'undefined' && process.versions && process.versions.node)
   global.mulberry32 = mulberry32;
   global.computeNextSpawnGap = computeNextSpawnGap;
   global.pickObstacleType = pickObstacleType;
+  global.MODES = MODES;
+  global.setMode = setMode;
+  global.loadMode = loadMode;
 }

--- a/style.css
+++ b/style.css
@@ -12,6 +12,7 @@ body {
 }
 
 #game-wrapper {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -19,6 +20,36 @@ body {
   max-width: 600px;
   padding: 0 8px;
 }
+
+#mode-btn {
+  position: absolute;
+  top: 6px;
+  right: 14px;
+  z-index: 2;
+  padding: 4px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: rgba(255, 255, 255, 0.85);
+  color: #333;
+  border: 1px solid #999;
+  border-radius: 999px;
+  cursor: pointer;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  transition: background-color 80ms ease-out, color 80ms ease-out, transform 80ms ease-out;
+}
+
+#mode-btn[data-mode='classic'] {
+  background: rgba(40, 40, 40, 0.85);
+  color: #f0f0f0;
+  border-color: #444;
+}
+
+#mode-btn:hover { transform: scale(1.04); }
+#mode-btn:active { transform: scale(0.96); }
+#mode-btn:focus-visible { outline: 2px solid #4a90e2; outline-offset: 2px; }
 
 #gameCanvas {
   border: 1px solid black;

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -296,6 +296,55 @@ describe('Spawn Gap Jitter', () => {
   });
 });
 
+describe('Mode Toggle', () => {
+  it('loadMode defaults to updated when nothing is stored', () => {
+    localStorage.removeItem('dino-mode');
+    assertEquals(loadMode(), MODES.UPDATED, 'Default should be updated');
+  });
+
+  it('loadMode returns classic when classic was previously stored', () => {
+    localStorage.setItem('dino-mode', MODES.CLASSIC);
+    assertEquals(loadMode(), MODES.CLASSIC, 'Stored classic should round-trip');
+    localStorage.removeItem('dino-mode'); // reset for siblings
+  });
+
+  it('classic mode forces small cactus regardless of score or rng', () => {
+    const rng = mulberry32(99);
+    for (const score of [0, 100, 250, 1000]) {
+      for (let i = 0; i < 50; i++) {
+        const t = pickObstacleType(rng, score, MODES.CLASSIC);
+        assertEquals(t.id, 'small', `Classic@${score}: expected small, got ${t.id}`);
+      }
+    }
+  });
+
+  it('classic mode returns deterministic gap (no jitter)', () => {
+    const rng = () => 0; // worst-case jitter input
+    const a = computeNextSpawnGap(rng, GAME_CONFIG.INITIAL_SPEED, MODES.CLASSIC);
+    const b = computeNextSpawnGap(rng, GAME_CONFIG.INITIAL_SPEED, MODES.CLASSIC);
+    assertEquals(a, b, 'Classic gap should not vary');
+    assertEquals(a, GAME_CONFIG.MAX_SPAWN_GAP,
+      `At INITIAL_SPEED, classic gap should be MAX_SPAWN_GAP (${GAME_CONFIG.MAX_SPAWN_GAP}), got ${a}`);
+  });
+
+  it('updated mode still produces variety', () => {
+    const rng = mulberry32(11);
+    const gaps = new Set();
+    for (let i = 0; i < 30; i++) gaps.add(computeNextSpawnGap(rng, 8, MODES.UPDATED));
+    assert(gaps.size >= 5, `Updated mode should jitter; got ${gaps.size} distinct values`);
+  });
+
+  it('setMode persists choice and resets the game', () => {
+    setMode(MODES.CLASSIC);
+    assertEquals(game.mode, MODES.CLASSIC, 'Mode should flip');
+    assertEquals(localStorage.getItem('dino-mode'), MODES.CLASSIC, 'Mode should be persisted');
+    assertEquals(game.score, 0, 'setMode should reset the run');
+    cancelAnimationFrame(game.animationFrameId);
+    setMode(MODES.UPDATED); // reset for siblings
+    cancelAnimationFrame(game.animationFrameId);
+  });
+});
+
 describe('Obstacle Types', () => {
   it('only returns small cactus when score < 100', () => {
     const rng = mulberry32(1);


### PR DESCRIPTION
A small pill button in the top-right corner of the canvas flips between two play styles. Choice is remembered across reloads.

## What each mode is

- **Classic** — single small cactus, deterministic spawn gap, the spartan original Chrome T-Rex feel.
- **Updated** — variable obstacle types (small / big / cluster) + ±30% spawn-gap jitter. The v0 of the juice plan; future phases (particles, SFX, death flash) will also gate on this flag so Classic stays a clean reference.

Default for first-time players: **Updated**.

## How it works

- `game.mode` is loaded from `localStorage['dino-mode']` at boot.
- `computeNextSpawnGap(rng, speed, mode)` and `pickObstacleType(rng, score, mode)` now take `mode` as their last arg; classic short-circuits to deterministic-gap and small-cactus respectively.
- `setMode()` persists the choice, refreshes the button label, and restarts the run so the new mode's spawn rules take effect cleanly.
- Button is accessible: `aria-pressed`, `aria-label` that update on toggle, plus a screen-reader announcement ("Classic mode" / "Updated mode") on change.
- Visual: subtle white pill in updated mode, dark pill in classic — matches the day/night feel.

## Test plan

- [x] `node tests/game.test.js` — 39/39 passing locally (6 new: default mode, persistence round-trip, classic forces small, deterministic gap, updated still varies, setMode side-effects).
- [ ] CI test job passes.
- [ ] After deploy at https://snehiths19.github.io/chrome-offline-Rex/:
  - [ ] Pill visible top-right, says "Updated" by default.
  - [ ] Click → flips to "Classic" (dark pill); game restarts.
  - [ ] In classic: only small cacti, gaps look constant.
  - [ ] Click → flips back to "Updated"; obstacles vary again.
  - [ ] Reload page: last-chosen mode sticks.
  - [ ] On mobile: button doesn't interfere with the on-screen jump button.

## Out of scope

Phases 3+ of the juice plan (particles, SFX, death flash, milestone confetti). When those land they'll gate on `game.mode === 'updated'` so the Classic side stays clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsMJsjjBrWUbWgC7c7tWrB)_