### PR TITLE
PR-1: Mode toggle as segmented control (both options visible)

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,10 @@
 </head>
 <body>
   <div id="game-wrapper" role="application" aria-label="Chrome dino game">
-    <button id="mode-btn" type="button" aria-pressed="true" aria-label="Mode: Updated. Switch to Classic.">Updated</button>
+    <div id="mode-toggle" role="group" aria-label="Game mode">
+      <button type="button" data-mode="classic" aria-pressed="false">Classic</button>
+      <button type="button" data-mode="updated" aria-pressed="true">Updated</button>
+    </div>
     <canvas id="gameCanvas" width="600" height="200" aria-label="Dino running game. Press space to jump."></canvas>
     <button id="jump-btn" aria-label="Jump">TAP TO JUMP</button>
     <div id="a11y-live" class="sr-only" aria-live="polite" aria-atomic="true"></div>

--- a/script.js
+++ b/script.js
@@ -335,7 +335,7 @@ const game = {
 function setMode(newMode) {
   game.mode = newMode === MODES.CLASSIC ? MODES.CLASSIC : MODES.UPDATED;
   localStorage.setItem('dino-mode', game.mode);
-  refreshModeButtonLabel();
+  refreshModeToggle();
   // Restart the run cleanly so the new mode's spawn rules take effect immediately.
   cancelAnimationFrame(game.animationFrameId);
   resetGame();
@@ -591,24 +591,25 @@ if (jumpBtn) {
   jumpBtn.addEventListener('click', handleAction);
 }
 
-const modeBtn = document.getElementById('mode-btn');
-function refreshModeButtonLabel() {
-  if (!modeBtn) return;
-  const isClassic = game.mode === MODES.CLASSIC;
-  modeBtn.textContent = isClassic ? 'Classic' : 'Updated';
-  modeBtn.dataset.mode = game.mode;
-  modeBtn.setAttribute('aria-pressed', String(!isClassic));
-  modeBtn.setAttribute(
-    'aria-label',
-    isClassic ? 'Mode: Classic. Switch to Updated.' : 'Mode: Updated. Switch to Classic.'
-  );
+// Segmented toggle: two buttons, both always visible, exactly one pressed.
+const modeToggle = document.getElementById('mode-toggle');
+function refreshModeToggle() {
+  if (!modeToggle || !modeToggle.querySelectorAll) return;
+  const buttons = modeToggle.querySelectorAll('button');
+  buttons.forEach(btn => {
+    const pressed = btn.dataset && btn.dataset.mode === game.mode;
+    btn.setAttribute('aria-pressed', String(pressed));
+  });
 }
-if (modeBtn) {
-  modeBtn.addEventListener('click', () => {
-    setMode(game.mode === MODES.CLASSIC ? MODES.UPDATED : MODES.CLASSIC);
+if (modeToggle && modeToggle.addEventListener) {
+  modeToggle.addEventListener('click', (event) => {
+    const target = event.target;
+    if (!target || !target.dataset || !target.dataset.mode) return;
+    if (target.dataset.mode === game.mode) return; // already in that mode
+    setMode(target.dataset.mode);
     announce(game.mode === MODES.CLASSIC ? 'Classic mode' : 'Updated mode');
   });
-  refreshModeButtonLabel();
+  refreshModeToggle();
 }
 
 // == SECTION 8: GAME LOOP ==

--- a/style.css
+++ b/style.css
@@ -21,35 +21,43 @@ body {
   padding: 0 8px;
 }
 
-#mode-btn {
+#mode-toggle {
   position: absolute;
   top: 6px;
   right: 14px;
   z-index: 2;
+  display: inline-flex;
+  padding: 2px;
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid #999;
+  border-radius: 999px;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+#mode-toggle button {
+  appearance: none;
+  -webkit-appearance: none;
   padding: 4px 12px;
   font-size: 12px;
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  background: rgba(255, 255, 255, 0.85);
-  color: #333;
-  border: 1px solid #999;
+  background: transparent;
+  color: #888;
+  border: 0;
   border-radius: 999px;
   cursor: pointer;
-  user-select: none;
-  -webkit-tap-highlight-color: transparent;
-  transition: background-color 80ms ease-out, color 80ms ease-out, transform 80ms ease-out;
+  transition: background-color 120ms ease-out, color 120ms ease-out;
 }
 
-#mode-btn[data-mode='classic'] {
-  background: rgba(40, 40, 40, 0.85);
-  color: #f0f0f0;
-  border-color: #444;
+#mode-toggle button[aria-pressed='true'] {
+  background: #333;
+  color: #fff;
 }
 
-#mode-btn:hover { transform: scale(1.04); }
-#mode-btn:active { transform: scale(0.96); }
-#mode-btn:focus-visible { outline: 2px solid #4a90e2; outline-offset: 2px; }
+#mode-toggle button:hover:not([aria-pressed='true']) { color: #555; }
+#mode-toggle button:focus-visible { outline: 2px solid #4a90e2; outline-offset: 2px; }
 
 #gameCanvas {
   border: 1px solid black;


### PR DESCRIPTION
## Why

After PR #12 the mode toggle was a single pill labeled "Updated" that flipped to "Classic" on click. The user said: *"updated looks like the only thing i can click. do not see classic updated toggle."* — they couldn't tell it was a toggle because there was nothing to compare against.

## What

Two pills, both always visible, side by side. iOS-style segmented control. The active mode is filled (dark), the inactive is faint. Click either to switch.

```html
<div id="mode-toggle" role="group" aria-label="Game mode">
  <button data-mode="classic" aria-pressed="false">Classic</button>
  <button data-mode="updated" aria-pressed="true">Updated</button>
</div>
```

- Click handler is delegated on the container, reads `event.target.dataset.mode`, calls existing `setMode()`.
- `aria-pressed` updates on both buttons each refresh — accessible state.
- No-op if you click the already-active mode (no needless restart).
- `setMode()`, persistence (`localStorage['dino-mode']`), restart-on-switch behaviour all unchanged.

## Test plan

- [x] `node tests/game.test.js` — 39/39 still passing.
- [ ] CI test job passes.
- [ ] After deploy: toggle visible top-right, both pills shown.
- [ ] Click "Classic" → left pill fills, game restarts in Classic.
- [ ] Click "Updated" → right pill fills, game restarts in Updated.
- [ ] Reload remembers last choice.
- [ ] Mobile: both pills fit inside the 600px wrapper.
- [ ] Keyboard: Tab between pills, Enter/Space to activate.

## Out of scope

This is the first PR of the broader juiced-up plan. Particles / SFX / death flash / confetti land in PR-A through PR-D after this.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsMJsjjBrWUbWgC7c7tWrB)_