### PR TITLE
PR-C: Death flash + score pop

### DIFF
--- a/script.js
+++ b/script.js
@@ -27,6 +27,7 @@ if (typeof process !== 'undefined' && process.versions && process.versions.node)
             save: () => {},
             restore: () => {},
             translate: () => {},
+            scale: () => {},
             fillStyle: '',
             strokeStyle: '',
             font: '',
@@ -131,6 +132,8 @@ const GAME_CONFIG = Object.freeze({
   // --- Effects ---
   DEATH_SHAKE_FRAMES:      12,
   DEATH_SHAKE_AMPLITUDE:    4,
+  DEATH_FLASH_FRAMES:       6,    // PR-C: white-flash overlay length on collision
+  SCORE_POP_FRAMES:        12,    // PR-C: HUD score scale-up duration during death shake
   MILESTONE_FRAMES:        90,
   NEW_BEST_FRAMES:        120,
 
@@ -385,6 +388,8 @@ const game = {
   stars:            [],
   starsInitialised: false,
   deathShakeFrames: 0,
+  deathFlashFrames: 0,
+  scorePopFrames:   0,
   milestoneText:    '',
   milestoneFrames:  0,
   newBestFrames:    0,
@@ -508,10 +513,34 @@ function drawDino() {
 }
 
 function drawScore() {
+  const popping = game.scorePopFrames > 0 && isUpdatedMode() && !reducedMotion;
+  if (popping) {
+    // Brief 1.0 → 1.4 ease-out scale around the score's centre on death.
+    const t = game.scorePopFrames / GAME_CONFIG.SCORE_POP_FRAMES; // 1 → 0
+    const scale = 1 + t * 0.4;
+    const cx = canvas.width - GAME_CONFIG.SCORE_X_OFFSET + 50;
+    const cy = GAME_CONFIG.SCORE_Y - 8;
+    ctx.save();
+    ctx.translate(cx, cy);
+    ctx.scale(scale, scale);
+    ctx.translate(-cx, -cy);
+  }
   ctx.fillStyle = game.score >= GAME_CONFIG.DAY_NIGHT_START ? '#ffffff' : '#000000';
   ctx.font = '20px Arial';
   ctx.textAlign = 'left';
   ctx.fillText('Score: ' + Math.floor(game.score), canvas.width - GAME_CONFIG.SCORE_X_OFFSET, GAME_CONFIG.SCORE_Y);
+  if (popping) ctx.restore();
+}
+
+// PR-C: white-flash overlay drawn on top of the world during the first few
+// post-death frames. Mode-gated; reduce-motion caps it at 1 frame.
+function drawDeathFlash() {
+  if (game.deathFlashFrames <= 0) return;
+  const alpha = game.deathFlashFrames / GAME_CONFIG.DEATH_FLASH_FRAMES;
+  ctx.save();
+  ctx.fillStyle = 'rgba(255, 255, 255, ' + alpha.toFixed(3) + ')';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.restore();
 }
 
 function drawGetReadyOverlay() {
@@ -784,6 +813,8 @@ function resetGame() {
   game.state = STATE.WAITING;
   game.starsInitialised = false;
   game.deathShakeFrames = 0;
+  game.deathFlashFrames = 0;
+  game.scorePopFrames = 0;
   game.milestoneFrames = 0;
   game.newBestFrames = 0;
   game.newBestShown = false;
@@ -807,7 +838,10 @@ function gameLoop() {
       drawDino();
       drawScore();
       ctx.restore();
+      drawDeathFlash(); // white flash drawn outside the shake transform so it stays canvas-aligned
       updateParticles();
+      if (game.deathFlashFrames > 0) game.deathFlashFrames--;
+      if (game.scorePopFrames > 0) game.scorePopFrames--;
       game.deathShakeFrames--;
       game.animationFrameId = requestAnimationFrame(gameLoop);
     } else {
@@ -893,6 +927,11 @@ function gameLoop() {
     if (checkCollision(dino, game.obstacles[i])) {
       game.state = STATE.DEAD;
       game.deathShakeFrames = GAME_CONFIG.DEATH_SHAKE_FRAMES;
+      // PR-C: white flash + score pop, mode-gated. Reduce-motion caps flash to 1 frame.
+      if (isUpdatedMode()) {
+        game.deathFlashFrames = reducedMotion ? 1 : GAME_CONFIG.DEATH_FLASH_FRAMES;
+        game.scorePopFrames = reducedMotion ? 0 : GAME_CONFIG.SCORE_POP_FRAMES;
+      }
       emitParticles('collision', dino.x + dino.width / 2, dino.y + dino.height / 2);
       audio.death();
       cancelAnimationFrame(game.animationFrameId);
@@ -978,4 +1017,5 @@ if (typeof process !== 'undefined' && process.versions && process.versions.node)
   global.updateParticles = updateParticles;
   global.drawParticles = drawParticles;
   global.audio = audio;
+  global.drawDeathFlash = drawDeathFlash;
 }

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -296,6 +296,65 @@ describe('Spawn Gap Jitter', () => {
   });
 });
 
+describe('Death flash + score pop (PR-C)', () => {
+  it('updated mode collision sets deathFlashFrames + scorePopFrames', () => {
+    setMode(MODES.UPDATED);
+    cancelAnimationFrame(game.animationFrameId);
+    resetGame();
+    game.state = STATE.RUNNING;
+    game.graceFrames = 0;
+    game.obstacles.push({ x: dino.x, y: canvas.height - 40, width: 20, height: 40 });
+    gameLoop();
+    cancelAnimationFrame(game.animationFrameId);
+    assertEquals(game.state, STATE.DEAD, 'should be dead');
+    assertEquals(game.deathFlashFrames, GAME_CONFIG.DEATH_FLASH_FRAMES, 'flash counter set');
+    assertEquals(game.scorePopFrames, GAME_CONFIG.SCORE_POP_FRAMES, 'score pop counter set');
+  });
+
+  it('classic mode collision leaves deathFlashFrames + scorePopFrames at 0', () => {
+    setMode(MODES.CLASSIC);
+    cancelAnimationFrame(game.animationFrameId);
+    resetGame();
+    game.state = STATE.RUNNING;
+    game.graceFrames = 0;
+    game.obstacles.push({ x: dino.x, y: canvas.height - 40, width: 20, height: 40 });
+    gameLoop();
+    cancelAnimationFrame(game.animationFrameId);
+    assertEquals(game.deathFlashFrames, 0, 'classic should not flash');
+    assertEquals(game.scorePopFrames, 0, 'classic should not pop');
+    setMode(MODES.UPDATED); // reset for siblings
+    cancelAnimationFrame(game.animationFrameId);
+  });
+
+  it('death flash decays to 0 across DEATH_FLASH_FRAMES frames during shake', () => {
+    setMode(MODES.UPDATED);
+    cancelAnimationFrame(game.animationFrameId);
+    resetGame();
+    game.state = STATE.RUNNING;
+    game.graceFrames = 0;
+    game.obstacles.push({ x: dino.x, y: canvas.height - 40, width: 20, height: 40 });
+    gameLoop(); // collision frame, sets DEAD + flash
+    cancelAnimationFrame(game.animationFrameId);
+    // Each subsequent DEAD-shake frame should decrement deathFlashFrames once.
+    for (let i = 0; i < GAME_CONFIG.DEATH_FLASH_FRAMES + 2; i++) {
+      gameLoop();
+      cancelAnimationFrame(game.animationFrameId);
+    }
+    assertEquals(game.deathFlashFrames, 0, 'flash should decay to 0');
+  });
+
+  it('resetGame clears deathFlashFrames + scorePopFrames', () => {
+    setMode(MODES.UPDATED);
+    cancelAnimationFrame(game.animationFrameId);
+    game.deathFlashFrames = 6;
+    game.scorePopFrames = 12;
+    resetGame();
+    cancelAnimationFrame(game.animationFrameId);
+    assertEquals(game.deathFlashFrames, 0, 'reset clears flash');
+    assertEquals(game.scorePopFrames, 0, 'reset clears pop');
+  });
+});
+
 describe('Audio (PR-B)', () => {
   it('audio.ensure() returns null in Node (no AudioContext)', () => {
     const result = audio.ensure();


### PR DESCRIPTION
Two extra "oof" effects on collision, **Updated mode only**.

## Death flash
- 6-frame full-canvas white overlay, alpha ramps `1.0 → 0` over the burst.
- Drawn **outside** the screen-shake transform so it stays canvas-aligned (otherwise the flash would visibly slosh with the shake).
- Counts down inside the existing `DEAD`-shake branch — no new render path.

## Score pop
- 12-frame ease-out scale on the HUD `Score: NNN` (1.0 → 1.4 → back to 1.0), centred on the score text. Pairs naturally with the death-shake duration so it settles to neutral right when the game-over panel takes over.

## Mode + reduced-motion gating
- Both gate on `isUpdatedMode()`. Classic stays a calm, low-key death (just the original 12-frame shake). Verified by test.
- `prefers-reduced-motion`:
  - Flash capped at **1 frame** (cue stays, churn drops).
  - Score pop **skipped entirely** (no scale transform).

## Implementation notes
- New state on `game`: `deathFlashFrames`, `scorePopFrames`. Cleared in `resetGame()`.
- New config: `DEATH_FLASH_FRAMES = 6`, `SCORE_POP_FRAMES = 12`.
- New helper: `drawDeathFlash()`. Score pop is inline in `drawScore()` so existing call sites keep working unchanged.
- Tiny test-stub fix: Node `ctx` mock now includes `scale: () => {}` (the new transform path was crashing tests until added).

## Test plan

- [x] `node tests/game.test.js` — 54/54 passing locally (4 new).
- [ ] CI test job passes.
- [ ] After deploy, hard refresh, then in **Updated** mode:
  - [ ] Crash → screen flashes white briefly, fades quickly.
  - [ ] Crash → HUD score visibly pops up + back, in sync with the shake.
- [ ] In **Classic** mode: crash → just the existing screen shake. No flash, no pop.
- [ ] OS reduce-motion on: flash is one frame, no pop.

## Out of scope (last in queue)

- PR-D: Milestone confetti + ambient depth (parallax hills + sky-tint pulses).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsMJsjjBrWUbWgC7c7tWrB)_