### PR TITLE
PR-D: Milestone confetti + ambient depth (parallax hills, sky-tint, stronger clouds)

### DIFF
--- a/script.js
+++ b/script.js
@@ -28,6 +28,7 @@ if (typeof process !== 'undefined' && process.versions && process.versions.node)
             restore: () => {},
             translate: () => {},
             scale: () => {},
+            ellipse: () => {},
             fillStyle: '',
             strokeStyle: '',
             font: '',
@@ -128,6 +129,18 @@ const GAME_CONFIG = Object.freeze({
   STAR_SIZE:                2,
   STAR_Y_RANGE:           100,
   STAR_COLOR:              '#ffffff',
+
+  // --- Ambient depth (PR-D, updated mode only) ---
+  HILL_COUNT:               3,    // mid-ground silhouette mounds
+  HILL_PARALLAX:            0.2,  // fraction of obstacle speed at which hills scroll
+  HILL_MIN_WIDTH:         120,
+  HILL_WIDTH_RANGE:        80,
+  HILL_MIN_HEIGHT:         40,
+  HILL_HEIGHT_RANGE:       30,
+  HILL_COLOR_DAY:          '#cdcdcd',
+  HILL_COLOR_NIGHT:        '#3a3a55',
+  CLOUD_SPEED_FACTOR_UPDATED: 1.5, // multiply cloud speed in updated mode for stronger parallax
+  SKY_TINT_PEAK_ALPHA:      0.12, // gold sky-flash peak alpha during milestone
 
   // --- Effects ---
   DEATH_SHAKE_FRAMES:      12,
@@ -273,6 +286,7 @@ function startGameOnce() {
   assetsStarted = true;
   dino.y = canvas.height - dino.height;
   initClouds();
+  initHills();
   drawDino();
   game.state = STATE.WAITING;
   gameLoop();
@@ -387,6 +401,7 @@ const game = {
   clouds:           [],
   stars:            [],
   starsInitialised: false,
+  hills:            [],
   deathShakeFrames: 0,
   deathFlashFrames: 0,
   scorePopFrames:   0,
@@ -444,13 +459,78 @@ function initClouds() {
 
 function updateClouds() {
   if (reducedMotion) return;
+  // PR-D: stronger parallax in Updated mode so the world feels less static.
+  const speedFactor = isUpdatedMode() ? GAME_CONFIG.CLOUD_SPEED_FACTOR_UPDATED : 1;
   game.clouds.forEach(c => {
-    c.x -= c.speed;
+    c.x -= c.speed * speedFactor;
     if (c.x + GAME_CONFIG.CLOUD_WIDTH < 0) {
       c.x = canvas.width + GAME_CONFIG.CLOUD_RESPAWN_OFFSET;
       c.y = GAME_CONFIG.CLOUD_MIN_Y + Math.random() * GAME_CONFIG.CLOUD_Y_RANGE;
     }
   });
+}
+
+// --- Mid-ground hills (PR-D, updated mode only) ---
+// Soft mounds drawn behind the ground at slow parallax. Deterministic shape
+// per-run via game.rng so the same seed yields identical scenery.
+function initHills() {
+  game.hills.length = 0;
+  const slot = canvas.width / GAME_CONFIG.HILL_COUNT;
+  for (let i = 0; i < GAME_CONFIG.HILL_COUNT; i++) {
+    game.hills.push({
+      x:      i * slot + game.rng() * (slot - GAME_CONFIG.HILL_MIN_WIDTH),
+      width:  GAME_CONFIG.HILL_MIN_WIDTH + game.rng() * GAME_CONFIG.HILL_WIDTH_RANGE,
+      height: GAME_CONFIG.HILL_MIN_HEIGHT + game.rng() * GAME_CONFIG.HILL_HEIGHT_RANGE,
+    });
+  }
+}
+
+function updateHills() {
+  if (!isUpdatedMode() || reducedMotion) return;
+  for (const hill of game.hills) {
+    hill.x -= game.currentSpeed * GAME_CONFIG.HILL_PARALLAX;
+    if (hill.x + hill.width < 0) {
+      hill.x = canvas.width + Math.random() * 50;
+      hill.width = GAME_CONFIG.HILL_MIN_WIDTH + Math.random() * GAME_CONFIG.HILL_WIDTH_RANGE;
+      hill.height = GAME_CONFIG.HILL_MIN_HEIGHT + Math.random() * GAME_CONFIG.HILL_HEIGHT_RANGE;
+    }
+  }
+}
+
+function drawHills() {
+  if (!isUpdatedMode() || game.hills.length === 0) return;
+  // Pick a colour that contrasts with the day/night background.
+  ctx.fillStyle = game.score >= GAME_CONFIG.DAY_NIGHT_START
+    ? GAME_CONFIG.HILL_COLOR_NIGHT
+    : GAME_CONFIG.HILL_COLOR_DAY;
+  const baseY = canvas.height - 16;
+  for (const hill of game.hills) {
+    if (typeof ctx.ellipse !== 'function') {
+      // Fallback for environments without canvas.ellipse — draw a triangle.
+      ctx.beginPath();
+      ctx.moveTo(hill.x, baseY);
+      ctx.lineTo(hill.x + hill.width / 2, baseY - hill.height);
+      ctx.lineTo(hill.x + hill.width, baseY);
+      ctx.closePath();
+      ctx.fill();
+      continue;
+    }
+    ctx.beginPath();
+    ctx.ellipse(hill.x + hill.width / 2, baseY, hill.width / 2, hill.height, 0, 0, Math.PI, true);
+    ctx.fill();
+  }
+}
+
+// PR-D: gentle gold sky-tint pulse during a milestone flash. Subtle on top of
+// the existing day/night background.
+function drawSkyTint() {
+  if (!isUpdatedMode() || reducedMotion) return;
+  if (game.milestoneFrames <= 0) return;
+  const alpha = (game.milestoneFrames / GAME_CONFIG.MILESTONE_FRAMES) * GAME_CONFIG.SKY_TINT_PEAK_ALPHA;
+  ctx.save();
+  ctx.fillStyle = 'rgba(255, 215, 0, ' + alpha.toFixed(3) + ')';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.restore();
 }
 
 function drawClouds() {
@@ -612,6 +692,7 @@ const PARTICLE_KINDS = Object.freeze({
   land:      { count:  9, color: '#9c8770',         size: 3, life: 14, vyMin: -1.5, vyMax: -0.2, vxSpread: 2.5, gravity: 0.08 },
   trail:     { count:  1, color: 'rgba(150,150,150,0.55)', size: 2, life: 10, vyMin: -0.2, vyMax: 0.2, vxSpread: 0.4, gravity: 0    },
   collision: { count: 22, color: '#d04a2a',         size: 3, life: 24, vyMin: -3.0, vyMax: 1.0, vxSpread: 4.0, gravity: 0.10 },
+  confetti:  { count: 20, color: '#ffd700',         size: 3, life: 40, vyMin: -3.5, vyMax: -1.5, vxSpread: 3.0, gravity: 0.12 },
 });
 const PARTICLE_REDUCED_FACTOR = 0.25;
 
@@ -821,6 +902,7 @@ function resetGame() {
   game.rng = mulberry32(Date.now() & 0xffffffff);
   game.nextSpawnGap = computeNextSpawnGap(game.rng, game.currentSpeed, game.mode);
   initClouds();
+  initHills();
   announce('New game. Press space or tap to jump.');
 }
 
@@ -831,6 +913,7 @@ function gameLoop() {
       ctx.save();
       ctx.translate(Math.sin(game.deathShakeFrames * 1.5) * GAME_CONFIG.DEATH_SHAKE_AMPLITUDE, 0);
       drawBackground();
+      drawHills();
       drawGround();
       drawClouds();
       drawObstacles();
@@ -858,6 +941,7 @@ function gameLoop() {
       announce('Go!');
     }
     drawBackground();
+    drawHills();
     drawGround();
     updateClouds();
     drawClouds();
@@ -884,6 +968,7 @@ function gameLoop() {
     game.milestoneText = 'LEVEL ' + (level + 1);
     game.milestoneFrames = GAME_CONFIG.MILESTONE_FRAMES;
     audio.milestone();
+    emitParticles('confetti', canvas.width - GAME_CONFIG.SCORE_X_OFFSET + 50, GAME_CONFIG.SCORE_Y);
   }
 
   // Scroll ground.
@@ -899,6 +984,8 @@ function gameLoop() {
   }
 
   drawBackground();
+  updateHills();
+  drawHills();
   drawGround();
   updateClouds();
   drawClouds();
@@ -969,6 +1056,7 @@ function gameLoop() {
 
   drawDino();
   drawScore();
+  drawSkyTint();
   drawMilestoneFlash();
   drawNewBestBadge();
 
@@ -1018,4 +1106,8 @@ if (typeof process !== 'undefined' && process.versions && process.versions.node)
   global.drawParticles = drawParticles;
   global.audio = audio;
   global.drawDeathFlash = drawDeathFlash;
+  global.initHills = initHills;
+  global.updateHills = updateHills;
+  global.drawHills = drawHills;
+  global.drawSkyTint = drawSkyTint;
 }

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -296,6 +296,97 @@ describe('Spawn Gap Jitter', () => {
   });
 });
 
+describe('Ambient depth + confetti (PR-D)', () => {
+  it('initHills produces HILL_COUNT hills with stable shapes for the same seed', () => {
+    setMode(MODES.UPDATED);
+    cancelAnimationFrame(game.animationFrameId);
+    // Pin the RNG to a deterministic sequence.
+    game.rng = mulberry32(42);
+    initHills();
+    const snapshot1 = game.hills.map(h => ({ x: h.x, w: h.width, h: h.height }));
+    assertEquals(game.hills.length, GAME_CONFIG.HILL_COUNT, 'Hills count should match config');
+
+    // Re-seed identically and re-init — same hills.
+    game.rng = mulberry32(42);
+    initHills();
+    game.hills.forEach((h, i) => {
+      assertEquals(h.x, snapshot1[i].x, `Hill ${i} x should be deterministic`);
+      assertEquals(h.width, snapshot1[i].w, `Hill ${i} width should be deterministic`);
+      assertEquals(h.height, snapshot1[i].h, `Hill ${i} height should be deterministic`);
+    });
+  });
+
+  it('updateHills scrolls in updated mode but is a no-op in classic', () => {
+    setMode(MODES.UPDATED);
+    cancelAnimationFrame(game.animationFrameId);
+    game.rng = mulberry32(1);
+    initHills();
+    const beforeX = game.hills[0].x;
+    game.currentSpeed = 6;
+    updateHills();
+    assert(game.hills[0].x < beforeX, 'Hill should scroll left in updated mode');
+
+    setMode(MODES.CLASSIC);
+    cancelAnimationFrame(game.animationFrameId);
+    game.rng = mulberry32(1);
+    initHills();
+    const classicBefore = game.hills[0].x;
+    game.currentSpeed = 6;
+    updateHills();
+    assertEquals(game.hills[0].x, classicBefore, 'Classic mode should not scroll hills');
+    setMode(MODES.UPDATED); // reset for siblings
+    cancelAnimationFrame(game.animationFrameId);
+  });
+
+  it('updateHills respawns a hill on the right when it exits the left edge', () => {
+    setMode(MODES.UPDATED);
+    cancelAnimationFrame(game.animationFrameId);
+    game.rng = mulberry32(7);
+    initHills();
+    const hill = game.hills[0];
+    hill.x = -hill.width - 1; // already past left edge
+    game.currentSpeed = 6;
+    updateHills();
+    assert(hill.x >= canvas.width, `Respawned hill x (${hill.x}) should be at/past right edge (${canvas.width})`);
+  });
+
+  it('confetti is a registered particle kind', () => {
+    assert(PARTICLE_KINDS.confetti, 'PARTICLE_KINDS should include confetti');
+    assert(PARTICLE_KINDS.confetti.color === '#ffd700', 'Confetti should be gold');
+  });
+
+  it('level-up emits confetti in updated mode', () => {
+    setMode(MODES.UPDATED);
+    cancelAnimationFrame(game.animationFrameId);
+    resetGame();
+    game.state = STATE.RUNNING;
+    game.graceFrames = 0;
+    // Clear pool and fast-forward to just before a level boundary.
+    for (let i = 0; i < particles.length; i++) particles[i].life = 0;
+    game.score = GAME_CONFIG.SCORE_PER_LEVEL - 0.05; // next gameLoop tick crosses
+    gameLoop();
+    cancelAnimationFrame(game.animationFrameId);
+    const live = particles.filter(p => p.life > 0 && p.color === '#ffd700').length;
+    assert(live > 0, `Should have emitted at least one gold confetti particle, got ${live}`);
+  });
+
+  it('level-up does not emit confetti in classic mode', () => {
+    setMode(MODES.CLASSIC);
+    cancelAnimationFrame(game.animationFrameId);
+    resetGame();
+    game.state = STATE.RUNNING;
+    game.graceFrames = 0;
+    for (let i = 0; i < particles.length; i++) particles[i].life = 0;
+    game.score = GAME_CONFIG.SCORE_PER_LEVEL - 0.05;
+    gameLoop();
+    cancelAnimationFrame(game.animationFrameId);
+    const gold = particles.filter(p => p.life > 0 && p.color === '#ffd700').length;
+    assertEquals(gold, 0, 'Classic mode should not spawn confetti');
+    setMode(MODES.UPDATED);
+    cancelAnimationFrame(game.animationFrameId);
+  });
+});
+
 describe('Death flash + score pop (PR-C)', () => {
   it('updated mode collision sets deathFlashFrames + scorePopFrames', () => {
     setMode(MODES.UPDATED);


### PR DESCRIPTION
Last PR in the aesthetic juice plan. Adds celebration on level-up + atmospheric depth to the world. **Updated mode only** — Classic stays a clean Chrome T-Rex reference.

## Confetti

New `confetti` particle kind reuses the PR-A pool. **20 gold particles** burst from the HUD score on every level-up, pairing with the existing `audio.milestone()` ding and the gold "LEVEL X" milestone flash.

## Ambient depth

Three additions that make the world feel less static at higher levels:

| Layer | Behaviour |
|---|---|
| **Mid-ground hills** | 3 soft mounds drawn behind the ground at **0.2× obstacle speed** (slow parallax). Procedurally placed via `game.rng` so the same seed yields identical scenery — re-runs are deterministic. Colour swaps day → night (light grey → dark indigo). |
| **Cloud parallax** | 1.5× cloud speed in Updated; Classic unchanged. |
| **Sky tint** | Gentle gold pulse over the background during a milestone flash (peak alpha 0.12, decays with `milestoneFrames`). |

## Reduced-motion gating

- **Hills**: don't scroll (drawn statically once per run).
- **Clouds**: already gated — skipped entirely under `reducedMotion`.
- **Sky tint**: disabled.

## Implementation notes

- New state on `game`: `hills[]`. `initHills()` called from `startGameOnce()` and `resetGame()` so hills exist from frame 0.
- `drawHills()` uses `ctx.ellipse` where available, with a triangle fallback for older canvas implementations.
- Tiny stub fix: Node `ctx` mock now includes `ellipse: () => {}`.

## Test plan

- [x] `node tests/game.test.js` — **60/60 passing locally** (6 new: deterministic-seed → identical hills, scrolls in updated only, respawn-on-left-edge, confetti registered, level-up emits in updated, level-up doesn't emit in classic).
- [ ] CI test job passes.
- [ ] After deploy, hard refresh, then in **Updated** mode:
  - [ ] Soft grey/indigo hills visible behind the ground, scrolling slowly.
  - [ ] Clouds visibly faster than before.
  - [ ] Cross score 100 (or any 100-mark) → gold confetti bursts from the HUD score, sky briefly tints gold.
- [ ] Switch to **Classic**: hills disappear, clouds slow back down, level-up is silent + confetti-free.
- [ ] OS reduce-motion: hills present but static; sky tint off.

## Plan complete

Closes the aesthetic-juice plan: PR-1 (toggle UX) + PR-A (particles) + PR-B (audio) + PR-C (death flash + score pop) + PR-D (this). All five merged → Updated mode is now visibly + audibly + atmospherically distinct from Classic, with classic gameplay rules entirely preserved on the Classic side.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsMJsjjBrWUbWgC7c7tWrB)_