### PR TITLE
fix(polish): PR-P1 — hill RNG, audio resume, button bubbling, NEW BEST stagger

### DIFF
--- a/script.js
+++ b/script.js
@@ -181,12 +181,16 @@ const audio = {
   ctx: null,
   muted: localStorage.getItem('dino-muted') === '1',
   ensure() {
-    if (this.ctx) return this.ctx;
-    const Ctx = (typeof AudioContext !== 'undefined') ? AudioContext
-              : (typeof webkitAudioContext !== 'undefined') ? webkitAudioContext
-              : null;
-    if (!Ctx) return null;
-    try { this.ctx = new Ctx(); } catch (e) { this.ctx = null; }
+    if (!this.ctx) {
+      const Ctx = (typeof AudioContext !== 'undefined') ? AudioContext
+                : (typeof webkitAudioContext !== 'undefined') ? webkitAudioContext
+                : null;
+      if (!Ctx) return null;
+      try { this.ctx = new Ctx(); } catch (e) { this.ctx = null; }
+    }
+    if (this.ctx && this.ctx.state === 'suspended' && typeof this.ctx.resume === 'function') {
+      this.ctx.resume().catch(() => { /* swallow autoplay-block etc. */ });
+    }
     return this.ctx;
   },
   setMuted(v) {
@@ -490,9 +494,9 @@ function updateHills() {
   for (const hill of game.hills) {
     hill.x -= game.currentSpeed * GAME_CONFIG.HILL_PARALLAX;
     if (hill.x + hill.width < 0) {
-      hill.x = canvas.width + Math.random() * 50;
-      hill.width = GAME_CONFIG.HILL_MIN_WIDTH + Math.random() * GAME_CONFIG.HILL_WIDTH_RANGE;
-      hill.height = GAME_CONFIG.HILL_MIN_HEIGHT + Math.random() * GAME_CONFIG.HILL_HEIGHT_RANGE;
+      hill.x = canvas.width + game.rng() * 50;
+      hill.width = GAME_CONFIG.HILL_MIN_WIDTH + game.rng() * GAME_CONFIG.HILL_WIDTH_RANGE;
+      hill.height = GAME_CONFIG.HILL_MIN_HEIGHT + game.rng() * GAME_CONFIG.HILL_HEIGHT_RANGE;
     }
   }
 }
@@ -676,7 +680,10 @@ function drawNewBestBadge() {
   ctx.fillStyle = '#ffd700';
   ctx.textAlign = 'left';
   ctx.font = 'bold 14px Arial';
-  ctx.fillText('NEW BEST!', canvas.width - GAME_CONFIG.SCORE_X_OFFSET, 70);
+  // Drop below the milestone flash when both fire on the same frame
+  // (level-up + new-best at score = highScore + 100).
+  const y = game.milestoneFrames > 0 ? 100 : 70;
+  ctx.fillText('NEW BEST!', canvas.width - GAME_CONFIG.SCORE_X_OFFSET, y);
   ctx.restore();
   game.newBestFrames--;
 }
@@ -845,13 +852,24 @@ function refreshModeToggle() {
   });
 }
 if (modeToggle && modeToggle.addEventListener) {
-  modeToggle.addEventListener('click', (event) => {
+  // stopPropagation + a touchstart shadow stops the synthesised click from
+  // also firing the canvas's jump handler when the buttons sit over it.
+  const onModeTap = (event) => {
     const target = event.target;
     if (!target || !target.dataset || !target.dataset.mode) return;
+    event.stopPropagation();
     if (target.dataset.mode === game.mode) return; // already in that mode
     setMode(target.dataset.mode);
     announce(game.mode === MODES.CLASSIC ? 'Classic mode' : 'Updated mode');
-  });
+  };
+  modeToggle.addEventListener('click', onModeTap);
+  modeToggle.addEventListener('touchstart', (event) => {
+    if (event.target && event.target.dataset && event.target.dataset.mode) {
+      event.preventDefault();
+      event.stopPropagation();
+      onModeTap(event);
+    }
+  }, { passive: false });
   refreshModeToggle();
 }
 
@@ -864,13 +882,33 @@ function refreshMuteButton() {
   muteBtn.setAttribute('aria-label', audio.muted ? 'Unmute sound' : 'Mute sound');
 }
 if (muteBtn && muteBtn.addEventListener) {
-  muteBtn.addEventListener('click', () => {
-    audio.ensure(); // also unlocks AudioContext if not yet
+  const onMuteTap = (event) => {
+    if (event) event.stopPropagation();
+    audio.ensure(); // also unlocks (and resumes) AudioContext if not yet
     audio.setMuted(!audio.muted);
     refreshMuteButton();
     announce(audio.muted ? 'Sound muted' : 'Sound on');
-  });
+  };
+  muteBtn.addEventListener('click', onMuteTap);
+  muteBtn.addEventListener('touchstart', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    onMuteTap(event);
+  }, { passive: false });
   refreshMuteButton();
+}
+
+// Resume the AudioContext when the tab becomes visible again. Browsers
+// suspend the ctx when the page is hidden; without this, audio dies silently
+// on tab-switch even though no error is thrown.
+if (typeof document !== 'undefined' && document.addEventListener) {
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible' && audio.ctx
+        && audio.ctx.state === 'suspended'
+        && typeof audio.ctx.resume === 'function') {
+      audio.ctx.resume().catch(() => {});
+    }
+  });
 }
 
 // == SECTION 8: GAME LOOP ==
@@ -1106,6 +1144,8 @@ if (typeof process !== 'undefined' && process.versions && process.versions.node)
   global.drawParticles = drawParticles;
   global.audio = audio;
   global.drawDeathFlash = drawDeathFlash;
+  global.drawMilestoneFlash = drawMilestoneFlash;
+  global.drawNewBestBadge = drawNewBestBadge;
   global.initHills = initHills;
   global.updateHills = updateHills;
   global.drawHills = drawHills;

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -834,6 +834,69 @@ describe('State Transitions', () => {
   });
 });
 
+describe('PR-P1 bug fixes', () => {
+  it('updateHills respawn uses game.rng (consumes exactly 3 draws)', () => {
+    setMode(MODES.UPDATED);
+    cancelAnimationFrame(game.animationFrameId);
+    game.rng = mulberry32(123);
+    initHills();
+    // Force the first hill off-screen so updateHills will respawn it.
+    game.hills[0].x = -game.hills[0].width - 1;
+    game.currentSpeed = 6;
+
+    let calls = 0;
+    const inner = mulberry32(456);
+    game.rng = () => { calls++; return inner(); };
+    updateHills();
+
+    assertEquals(calls, 3, 'Respawn must consume exactly 3 game.rng() draws');
+    assert(game.hills[0].x >= canvas.width,
+      'Respawned x must land at or past canvas width');
+  });
+
+  it('audio.ensure resumes a suspended context', () => {
+    let resumed = 0;
+    const prev = audio.ctx;
+    audio.ctx = { state: 'suspended', resume: () => { resumed++; return Promise.resolve(); } };
+    audio.ensure();
+    assertEquals(resumed, 1, 'ensure() must call resume() on suspended ctx');
+    audio.ctx = prev;
+  });
+
+  it('audio.ensure does not call resume on running context', () => {
+    let resumed = 0;
+    const prev = audio.ctx;
+    audio.ctx = { state: 'running', resume: () => { resumed++; return Promise.resolve(); } };
+    audio.ensure();
+    assertEquals(resumed, 0, 'ensure() must not resume an already-running ctx');
+    audio.ctx = prev;
+  });
+
+  it('drawNewBestBadge offsets vertically when milestone is active', () => {
+    const calls = [];
+    const origFill = ctx.fillText;
+    ctx.fillText = (text, x, y) => calls.push({ text, x, y });
+
+    game.milestoneFrames = 0;
+    game.newBestFrames = GAME_CONFIG.NEW_BEST_FRAMES;
+    drawNewBestBadge();
+    const baseY = calls[calls.length - 1].y;
+
+    game.milestoneFrames = GAME_CONFIG.MILESTONE_FRAMES;
+    game.newBestFrames = GAME_CONFIG.NEW_BEST_FRAMES;
+    drawNewBestBadge();
+    const offsetY = calls[calls.length - 1].y;
+
+    assert(offsetY > baseY,
+      `NEW BEST y should drop when milestone active (base ${baseY}, offset ${offsetY})`);
+    assertEquals(offsetY - baseY, 30, 'Stagger should be exactly 30px');
+
+    ctx.fillText = origFill;
+    game.milestoneFrames = 0;
+    game.newBestFrames = 0;
+  });
+});
+
 // --- Test Summary ---
 // Print summary both in the browser (on window.onload) and in Node (via a
 // setTimeout fallback so async tests have time to complete).


### PR DESCRIPTION
First of four small PRs in the polish-pass plan. Four real bugs surfaced by the audit; this PR ships only the bug fixes (P2 registry refactor, P3 visual config, P4 docs follow as separate PRs).

## Summary

1. **Hill respawn determinism** (`script.js:493–495`) — `updateHills()` used `Math.random()` while `initHills()` used the seeded `game.rng`. Once a hill exited the left edge mid-run, the seed no longer reproduced the scenery. Three character-level swaps.
2. **AudioContext suspension** (`script.js:184` + new visibility listener) — `audio.ensure()` lazy-created the ctx but never resumed it. Tab-switch silently killed sound until reload. Now `ensure()` resumes a suspended ctx (covers iOS Safari where `visibilitychange` is unreliable) and a single `visibilitychange` handler resumes on tab return.
3. **Button event bubbling** (`script.js:851–878`) — mute and mode-toggle buttons sit absolute-positioned over the canvas. Tapping either on mobile also fired the canvas's jump handler. Added `stopPropagation` to both click handlers and a `touchstart` shadow that `preventDefault`s the synthesised click.
4. **NEW BEST + milestone overlap** (`script.js:676–688`) — both flashes can fire on the same frame (score = highScore + 100). Drop NEW BEST y from 70 → 100 while `milestoneFrames > 0` so they read as a sequence.

## Tests

4 new tests in `describe('PR-P1 bug fixes', ...)`:

- `updateHills respawn uses game.rng (consumes exactly 3 draws)` — wraps `game.rng` to count calls and asserts respawn consumes exactly 3.
- `audio.ensure resumes a suspended context` — stubbed ctx with `state: 'suspended'`, asserts `resume()` called once.
- `audio.ensure does not call resume on running context` — same stub with `state: 'running'`, asserts `resume()` not called.
- `drawNewBestBadge offsets vertically when milestone is active` — spies on `ctx.fillText`; asserts y-offset is exactly 30px when milestone is firing.

DOM-event bubbling fix is manual-verified — the test harness has no JSDOM.

## Test plan

- [x] `node tests/game.test.js` — 64/64 passing locally (was 60).
- [ ] CI `test` job passes.
- [ ] On mobile (post-deploy): tap mute → jump does **not** fire.
- [ ] On mobile: tap mode-toggle → jump does **not** fire.
- [ ] Switch tab away during a run, switch back — sound still plays on next jump.
- [ ] Force `score = highScore + 100` (or play to it) — NEW BEST badge sits below the LEVEL flash, not behind/over it.
- [ ] Hill scenery looks consistent across resets with the same seed.

## What's NOT in this PR

PR-P2 (features registry refactor), PR-P3 (visual config + live-tuning hook), PR-P4 (README + CLAUDE.md). Those follow as separate PRs per the plan.

---

https://claude.ai/code/session_01DsMJsjjBrWUbWgC7c7tWrB

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsMJsjjBrWUbWgC7c7tWrB)_