### PR TITLE
feat(polish): PR-P3 — visual config consolidation + live-tuning hook

### DIFF
--- a/script.js
+++ b/script.js
@@ -137,15 +137,20 @@ const GAME_CONFIG = Object.freeze({
   HILL_WIDTH_RANGE:        80,
   HILL_MIN_HEIGHT:         40,
   HILL_HEIGHT_RANGE:       30,
+  HILL_RESPAWN_X_RANGE:    50,    // px of jitter past the right edge when a hill respawns
   HILL_COLOR_DAY:          '#cdcdcd',
   HILL_COLOR_NIGHT:        '#3a3a55',
   CLOUD_SPEED_FACTOR_UPDATED: 1.5, // multiply cloud speed in updated mode for stronger parallax
   SKY_TINT_PEAK_ALPHA:      0.12, // gold sky-flash peak alpha during milestone
+  SKY_TINT_COLOR_RGB:      '255, 215, 0',   // gold sky-flash colour (rgb triplet, alpha applied at draw)
+  PARTICLE_EMIT_SPREAD:     4,    // px width of the cosmetic xy jitter on every particle emit
 
   // --- Effects ---
   DEATH_SHAKE_FRAMES:      12,
   DEATH_SHAKE_AMPLITUDE:    4,
+  DEATH_SHAKE_FREQ:         1.5,  // multiplier on the sin oscillation that drives the shake transform
   DEATH_FLASH_FRAMES:       6,    // PR-C: white-flash overlay length on collision
+  DEATH_FLASH_COLOR_RGB:   '255, 255, 255', // death-flash overlay colour (rgb triplet, alpha applied at draw)
   SCORE_POP_FRAMES:        12,    // PR-C: HUD score scale-up duration during death shake
   MILESTONE_FRAMES:        90,
   NEW_BEST_FRAMES:        120,
@@ -160,6 +165,40 @@ const GAME_CONFIG = Object.freeze({
   // --- Asset loading ---
   ASSET_LOAD_TIMEOUT_MS: 5000,    // force WAITING state even if assets never finish loading
 });
+
+// --- Live-tuning hook (visual-only) -----------------------------------
+// cfg(key) reads window.GAME_TUNING[key] when set, else falls back to
+// GAME_CONFIG[key]. ONLY use cfg() for visual keys (colours, alphas,
+// shake amplitude/freq, particle spread, parallax). Physics, spawning,
+// scoring, and hitboxes MUST continue to read GAME_CONFIG.X directly so
+// determinism is preserved across runs and tuning sessions.
+//
+// Workflow from DevTools:
+//   GAME_TUNING.SKY_TINT_PEAK_ALPHA = 0.3
+//   saveTuning()                            // persist to localStorage
+//   location.reload()                       // verify hydration
+function cfg(key) {
+  const t = window.GAME_TUNING;
+  if (t && Object.prototype.hasOwnProperty.call(t, key)) return t[key];
+  return GAME_CONFIG[key];
+}
+
+function loadTuning() {
+  window.GAME_TUNING = window.GAME_TUNING || {};
+  try {
+    const raw = localStorage.getItem('dino-tuning');
+    if (raw) Object.assign(window.GAME_TUNING, JSON.parse(raw));
+  } catch (e) { /* malformed JSON or disabled storage — keep defaults */ }
+}
+
+function saveTuning() {
+  try {
+    localStorage.setItem('dino-tuning', JSON.stringify(window.GAME_TUNING || {}));
+    return true;
+  } catch (e) { return false; }
+}
+
+loadTuning();
 
 const STATE = Object.freeze({
   LOADING: 'LOADING',
@@ -494,7 +533,7 @@ function updateHills() {
   for (const hill of game.hills) {
     hill.x -= game.currentSpeed * GAME_CONFIG.HILL_PARALLAX;
     if (hill.x + hill.width < 0) {
-      hill.x = canvas.width + game.rng() * 50;
+      hill.x = canvas.width + game.rng() * cfg('HILL_RESPAWN_X_RANGE');
       hill.width = GAME_CONFIG.HILL_MIN_WIDTH + game.rng() * GAME_CONFIG.HILL_WIDTH_RANGE;
       hill.height = GAME_CONFIG.HILL_MIN_HEIGHT + game.rng() * GAME_CONFIG.HILL_HEIGHT_RANGE;
     }
@@ -530,9 +569,9 @@ function drawHills() {
 function drawSkyTint() {
   if (!isUpdatedMode() || reducedMotion) return;
   if (game.milestoneFrames <= 0) return;
-  const alpha = (game.milestoneFrames / GAME_CONFIG.MILESTONE_FRAMES) * GAME_CONFIG.SKY_TINT_PEAK_ALPHA;
+  const alpha = (game.milestoneFrames / GAME_CONFIG.MILESTONE_FRAMES) * cfg('SKY_TINT_PEAK_ALPHA');
   ctx.save();
-  ctx.fillStyle = 'rgba(255, 215, 0, ' + alpha.toFixed(3) + ')';
+  ctx.fillStyle = 'rgba(' + cfg('SKY_TINT_COLOR_RGB') + ', ' + alpha.toFixed(3) + ')';
   ctx.fillRect(0, 0, canvas.width, canvas.height);
   ctx.restore();
 }
@@ -620,9 +659,9 @@ function drawScore() {
 // post-death frames. Mode-gated; reduce-motion caps it at 1 frame.
 function drawDeathFlash() {
   if (game.deathFlashFrames <= 0) return;
-  const alpha = game.deathFlashFrames / GAME_CONFIG.DEATH_FLASH_FRAMES;
+  const alpha = game.deathFlashFrames / cfg('DEATH_FLASH_FRAMES');
   ctx.save();
-  ctx.fillStyle = 'rgba(255, 255, 255, ' + alpha.toFixed(3) + ')';
+  ctx.fillStyle = 'rgba(' + cfg('DEATH_FLASH_COLOR_RGB') + ', ' + alpha.toFixed(3) + ')';
   ctx.fillRect(0, 0, canvas.width, canvas.height);
   ctx.restore();
 }
@@ -721,7 +760,7 @@ function emitParticles(kind, x, y) {
   for (let i = 0; i < particles.length && emitted < count; i++) {
     const p = particles[i];
     if (p.life > 0) continue;
-    p.x = x + (Math.random() - 0.5) * 4;
+    p.x = x + (Math.random() - 0.5) * cfg('PARTICLE_EMIT_SPREAD');
     p.y = y;
     p.vx = (Math.random() - 0.5) * 2 * config.vxSpread;
     p.vy = config.vyMin + Math.random() * (config.vyMax - config.vyMin);
@@ -972,7 +1011,7 @@ function gameLoop() {
   if (game.state === STATE.DEAD) {
     if (game.deathShakeFrames > 0) {
       ctx.save();
-      ctx.translate(Math.sin(game.deathShakeFrames * 1.5) * GAME_CONFIG.DEATH_SHAKE_AMPLITUDE, 0);
+      ctx.translate(Math.sin(game.deathShakeFrames * cfg('DEATH_SHAKE_FREQ')) * cfg('DEATH_SHAKE_AMPLITUDE'), 0);
       drawBackground();
       drawHills();
       drawGround();
@@ -1173,4 +1212,7 @@ if (typeof process !== 'undefined' && process.versions && process.versions.node)
   global.FEATURES = FEATURES;
   global.runFeatureUpdates = runFeatureUpdates;
   global.runFeatureDraws = runFeatureDraws;
+  global.cfg = cfg;
+  global.loadTuning = loadTuning;
+  global.saveTuning = saveTuning;
 }

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -972,6 +972,115 @@ describe('Feature registry (PR-P2)', () => {
   });
 });
 
+describe('Live-tuning hook (PR-P3)', () => {
+  // Snapshot/restore helper so tests don't leak overrides into siblings.
+  function withTuning(overrides, fn) {
+    const orig = window.GAME_TUNING;
+    window.GAME_TUNING = overrides;
+    try { fn(); } finally { window.GAME_TUNING = orig; }
+  }
+
+  it('cfg returns GAME_CONFIG value when no override is set', () => {
+    withTuning({}, () => {
+      assertEquals(cfg('SKY_TINT_PEAK_ALPHA'), GAME_CONFIG.SKY_TINT_PEAK_ALPHA);
+      assertEquals(cfg('HILL_RESPAWN_X_RANGE'), 50);
+      assertEquals(cfg('DEATH_SHAKE_FREQ'), 1.5);
+    });
+  });
+
+  it('cfg returns the override when GAME_TUNING[key] is set', () => {
+    withTuning({ SKY_TINT_PEAK_ALPHA: 0.5, DEATH_SHAKE_FREQ: 3.2 }, () => {
+      assertEquals(cfg('SKY_TINT_PEAK_ALPHA'), 0.5);
+      assertEquals(cfg('DEATH_SHAKE_FREQ'), 3.2);
+      // Non-overridden key still falls through to GAME_CONFIG.
+      assertEquals(cfg('HILL_RESPAWN_X_RANGE'), 50);
+    });
+  });
+
+  it('cfg ignores prototype-polluted keys', () => {
+    // Simulate a polluted prototype; cfg uses hasOwnProperty to skip it.
+    const polluted = Object.create({ JUMP_POWER: 999 });
+    withTuning(polluted, () => {
+      assertEquals(cfg('JUMP_POWER'), GAME_CONFIG.JUMP_POWER,
+        'Prototype keys must not leak through cfg');
+    });
+  });
+
+  it('saveTuning persists current GAME_TUNING to dino-tuning as JSON', () => {
+    withTuning({ SKY_TINT_PEAK_ALPHA: 0.3, HILL_RESPAWN_X_RANGE: 80 }, () => {
+      assert(saveTuning(), 'saveTuning should return true on success');
+      const raw = localStorage.getItem('dino-tuning');
+      assert(raw, 'localStorage should hold the dino-tuning entry');
+      const parsed = JSON.parse(raw);
+      assertEquals(parsed.SKY_TINT_PEAK_ALPHA, 0.3);
+      assertEquals(parsed.HILL_RESPAWN_X_RANGE, 80);
+    });
+    localStorage.removeItem('dino-tuning');
+  });
+
+  it('loadTuning hydrates from localStorage', () => {
+    localStorage.setItem('dino-tuning', JSON.stringify({ DEATH_SHAKE_FREQ: 2.5 }));
+    withTuning({}, () => {
+      loadTuning();
+      assertEquals(cfg('DEATH_SHAKE_FREQ'), 2.5);
+    });
+    localStorage.removeItem('dino-tuning');
+  });
+
+  it('save/load round-trip restores values', () => {
+    withTuning({ SKY_TINT_PEAK_ALPHA: 0.42 }, () => {
+      saveTuning();
+    });
+    withTuning({}, () => {
+      loadTuning();
+      assertEquals(cfg('SKY_TINT_PEAK_ALPHA'), 0.42,
+        'Override must survive a save/clear/load cycle');
+    });
+    localStorage.removeItem('dino-tuning');
+  });
+
+  it('loadTuning ignores malformed JSON without throwing', () => {
+    localStorage.setItem('dino-tuning', '{not json');
+    withTuning({}, () => {
+      loadTuning(); // must not throw
+      assert(typeof window.GAME_TUNING === 'object',
+        'GAME_TUNING must remain an object after malformed load');
+    });
+    localStorage.removeItem('dino-tuning');
+  });
+
+  it('drawSkyTint uses cfg-supplied colour string', () => {
+    setMode(MODES.UPDATED);
+    cancelAnimationFrame(game.animationFrameId);
+    // Pre-conditions for drawSkyTint to actually paint:
+    //   isUpdatedMode() && !reducedMotion && milestoneFrames > 0.
+    // The Node stub's matchMedia returns matches:false so reducedMotion is
+    // always false here — no need to guard.
+    game.milestoneFrames = GAME_CONFIG.MILESTONE_FRAMES;
+
+    const fillStyles = [];
+    const proto = Object.getPrototypeOf(ctx);
+    let captured = '';
+    Object.defineProperty(ctx, 'fillStyle', {
+      configurable: true,
+      get() { return captured; },
+      set(v) { captured = v; fillStyles.push(v); },
+    });
+
+    withTuning({ SKY_TINT_COLOR_RGB: '0, 0, 255' }, () => {
+      drawSkyTint();
+    });
+
+    // Restore: just delete our own property so the prototype value re-shows.
+    delete ctx.fillStyle;
+
+    const blueish = fillStyles.find(s => typeof s === 'string' && s.indexOf('rgba(0, 0, 255') === 0);
+    assert(blueish, `Expected a fillStyle starting with 'rgba(0, 0, 255' but got: ${JSON.stringify(fillStyles)}`);
+
+    game.milestoneFrames = 0;
+  });
+});
+
 // --- Test Summary ---
 // Print summary both in the browser (on window.onload) and in Node (via a
 // setTimeout fallback so async tests have time to complete).


### PR DESCRIPTION
Third of four small PRs in the polish-pass plan. Stacked on PR #20 (P2 registry); base is `claude/pr-p2-features-registry` so this picks up P2 once #20 merges. Final PR (P4 docs) follows.

## Why

After P1 + P2, five hardcoded visual values are still inline in `script.js` (sky-tint colour, death-flash colour, hill respawn jitter range, particle emit spread, death-shake frequency multiplier). Hardcoded inline = no way to A/B test them in production. `GAME_CONFIG` is `Object.freeze`d so DevTools can't even mutate it.

## What

1. **Five new keys in `GAME_CONFIG`** with current values unchanged:
   - `HILL_RESPAWN_X_RANGE: 50`
   - `SKY_TINT_COLOR_RGB: '255, 215, 0'`
   - `PARTICLE_EMIT_SPREAD: 4`
   - `DEATH_SHAKE_FREQ: 1.5`
   - `DEATH_FLASH_COLOR_RGB: '255, 255, 255'`

2. **`cfg(key)` indirection** between `GAME_CONFIG` (frozen) and the visual call sites:
   ```js
   function cfg(key) {
     const t = window.GAME_TUNING;
     if (t && Object.prototype.hasOwnProperty.call(t, key)) return t[key];
     return GAME_CONFIG[key];
   }
   ```
   Only visual call sites are routed through `cfg()`. Physics, spawning, scoring, and hitboxes still read `GAME_CONFIG.X` directly so gameplay determinism is preserved.

3. **`loadTuning()` / `saveTuning()`** persist `window.GAME_TUNING` to `localStorage['dino-tuning']` (JSON). `loadTuning()` runs at module load.

4. **DevTools workflow:**
   ```js
   GAME_TUNING.SKY_TINT_PEAK_ALPHA = 0.3
   saveTuning()
   location.reload()   // verify hydration
   ```

## Design decisions

- **No allow-list `Set`** for visual keys. Physics call sites still spell `GAME_CONFIG.JUMP_POWER` literally; no path for tuning to leak into physics unless a future contributor explicitly writes `cfg('JUMP_POWER')`. The big comment block above `cfg()` is the durable guard. An allow-list would force every new visual key to be added in two places for no determinism upside.
- **`saveTuning()` is a manual top-level function, not a Proxy on `GAME_TUNING`.** Manual save means no hammering localStorage on every keystroke, no `Object.assign` semantics fighting `loadTuning()`, and a clear DevTools idiom.
- **`loadTuning()` runs at module load**, not lazily on first `cfg()` read. Tunables must be visible to `initClouds()` / `initHills()` during boot.
- **`hasOwnProperty` check** prevents prototype-pollution leaks (e.g. `Object.prototype.JUMP_POWER` shouldn't reach `cfg`).

## Tests

8 new tests in `describe('Live-tuning hook (PR-P3)', ...)`:

- `cfg returns GAME_CONFIG value when no override is set`
- `cfg returns the override when GAME_TUNING[key] is set`
- `cfg ignores prototype-polluted keys`
- `saveTuning persists current GAME_TUNING to dino-tuning as JSON`
- `loadTuning hydrates from localStorage`
- `save/load round-trip restores values`
- `loadTuning ignores malformed JSON without throwing`
- `drawSkyTint uses cfg-supplied colour string` (end-to-end via `ctx.fillStyle` capture)

78/78 tests pass locally (was 70 with P2).

## Test plan

- [x] `node tests/game.test.js` — 78/78 passing locally.
- [ ] CI `test` job passes.
- [ ] After deploy: gameplay visually unchanged (all defaults preserved).
- [ ] DevTools: `GAME_TUNING.SKY_TINT_PEAK_ALPHA = 0.5; saveTuning(); location.reload();` — milestone flash visibly stronger after reload.
- [ ] DevTools: `GAME_TUNING.HILL_COLOR_DAY = '#b8b8b8'; saveTuning();` — hills greyer immediately (no reload needed for colour, since `drawHills` reads each frame).
- [ ] Reset tuning: `localStorage.removeItem('dino-tuning'); location.reload();` — visuals back to defaults.

## Stack note

This PR's base is `claude/pr-p2-features-registry`. Merge order: #19 → #20 → this. If either earlier PR rebases, rebase this branch.

## What's NOT in this PR

PR-P4 (README updates + CLAUDE.md) follows next.

---

https://claude.ai/code/session_01DsMJsjjBrWUbWgC7c7tWrB

---
_Generated by [Claude Code](https://claude.ai/code/session_01DsMJsjjBrWUbWgC7c7tWrB)_