### PR TITLE
P5: visible UX polish pass

### DIFF
--- a/docs/superpowers/plans/2026-04-25-visible-ux-polish-pass.md
+++ b/docs/superpowers/plans/2026-04-25-visible-ux-polish-pass.md
@@ -1,0 +1,682 @@
+# Visible UX Polish Pass Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship 7 visible polish items (HUD redesign, hill colour interpolation, body background sync, micro-fixes) as a single `script.js`-only PR.
+
+**Architecture:** All changes are confined to `script.js`. Three logical hunks — HUD redesign (font + score format + HI label), world visual fixes (hill colour + body background), micro-fixes (game-over "Best: 0" + dino animation in WAITING) — each independently reviewable but small enough to land as one PR.
+
+**Tech Stack:** Vanilla JS, HTML5 Canvas, custom Node test harness (`node tests/game.test.js`).
+
+---
+
+## File map
+
+| File | Role |
+|---|---|
+| `script.js` | Single source of truth — all 7 changes live here |
+| `tests/game.test.js` | Existing test suite; tasks 3, 4, 5 add new `describe` blocks |
+
+---
+
+### Task 1: Add two config keys to GAME_CONFIG
+
+**Files:**
+- Modify: `script.js:158–160` (HUD section of `GAME_CONFIG`)
+
+- [ ] **Step 1: Add the keys**
+
+  In `GAME_CONFIG`, replace the existing HUD block:
+
+  ```js
+  // --- HUD ---
+  SCORE_X_OFFSET:         150,    // pixels from right edge
+  SCORE_Y:                 30,
+  ```
+
+  with:
+
+  ```js
+  // --- HUD ---
+  SCORE_X_OFFSET:         150,    // pixels from right edge for the current-score label
+  SCORE_Y:                 30,
+  SCORE_HI_X_OFFSET:      110,    // additional px left of SCORE_X_OFFSET for the HI label
+  SCORE_FONT_FAMILY:      "'Courier New', Courier, monospace",
+  ```
+
+- [ ] **Step 2: Run the test suite to confirm no regressions**
+
+  ```
+  node tests/game.test.js
+  ```
+
+  Expected: all existing tests pass (no test touches these keys directly).
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add script.js
+  git commit -m "feat(polish): add SCORE_FONT_FAMILY + SCORE_HI_X_OFFSET config keys"
+  ```
+
+---
+
+### Task 2: Replace Arial with the monospace font stack everywhere
+
+**Files:**
+- Modify: `script.js` — 9 `ctx.font` assignments across 5 draw functions
+
+The pattern is: `'NNpx Arial'` → `'NNpx ' + cfg('SCORE_FONT_FAMILY')`. Bold variants follow the same rule: `'bold NNpx Arial'` → `'bold NNpx ' + cfg('SCORE_FONT_FAMILY')`.
+
+- [ ] **Step 1: Update `drawScore` (line ~652)**
+
+  Change:
+  ```js
+  ctx.font = '20px Arial';
+  ```
+  To:
+  ```js
+  ctx.font = '20px ' + cfg('SCORE_FONT_FAMILY');
+  ```
+
+- [ ] **Step 2: Update `drawGetReadyOverlay` (lines ~673, ~675, ~680)**
+
+  Change:
+  ```js
+  ctx.font = '28px Arial';
+  ```
+  To:
+  ```js
+  ctx.font = '28px ' + cfg('SCORE_FONT_FAMILY');
+  ```
+
+  Change:
+  ```js
+  ctx.font = '14px Arial';
+  ```
+  To:
+  ```js
+  ctx.font = '14px ' + cfg('SCORE_FONT_FAMILY');
+  ```
+
+  Change:
+  ```js
+  ctx.font = '48px Arial';
+  ```
+  To:
+  ```js
+  ctx.font = '48px ' + cfg('SCORE_FONT_FAMILY');
+  ```
+
+- [ ] **Step 3: Update `drawGameOverScreen` (lines ~692, ~695, ~699)**
+
+  Change:
+  ```js
+  ctx.font = '40px Arial';
+  ```
+  To:
+  ```js
+  ctx.font = '40px ' + cfg('SCORE_FONT_FAMILY');
+  ```
+
+  Change (first `'20px Arial'` inside this function):
+  ```js
+  ctx.font = '20px Arial';
+  ```
+  To:
+  ```js
+  ctx.font = '20px ' + cfg('SCORE_FONT_FAMILY');
+  ```
+
+  Change:
+  ```js
+  ctx.font = '16px Arial';
+  ```
+  To:
+  ```js
+  ctx.font = '16px ' + cfg('SCORE_FONT_FAMILY');
+  ```
+
+- [ ] **Step 4: Update `drawMilestoneFlash` (line ~709)**
+
+  Change:
+  ```js
+  ctx.font = 'bold 22px Arial';
+  ```
+  To:
+  ```js
+  ctx.font = 'bold 22px ' + cfg('SCORE_FONT_FAMILY');
+  ```
+
+- [ ] **Step 5: Update `drawNewBestBadge` (line ~721)**
+
+  Change:
+  ```js
+  ctx.font = 'bold 14px Arial';
+  ```
+  To:
+  ```js
+  ctx.font = 'bold 14px ' + cfg('SCORE_FONT_FAMILY');
+  ```
+
+- [ ] **Step 6: Verify no remaining Arial references**
+
+  ```bash
+  grep -n "Arial" script.js
+  ```
+
+  Expected: no output.
+
+- [ ] **Step 7: Run the test suite**
+
+  ```
+  node tests/game.test.js
+  ```
+
+  Expected: all existing tests pass.
+
+- [ ] **Step 8: Commit**
+
+  ```bash
+  git add script.js
+  git commit -m "feat(polish): replace Arial with monospace font stack across all HUD text"
+  ```
+
+---
+
+### Task 3: Zero-padded score + HI label in `drawScore` (TDD)
+
+**Files:**
+- Modify: `script.js:638–656` (`drawScore`)
+- Modify: `tests/game.test.js` (add describe block before the final line)
+
+- [ ] **Step 1: Write the failing tests**
+
+  Append this describe block to `tests/game.test.js` (before the closing of the file, after the last `});`):
+
+  ```js
+  describe('HUD score format (polish pass)', () => {
+    it('score renders as zero-padded 5-digit string without "Score:" prefix', () => {
+      const calls = [];
+      const origFill = ctx.fillText;
+      ctx.fillText = (text) => calls.push(String(text));
+      const origScore = game.score;
+      const origPop = game.scorePopFrames;
+      game.score = 42;
+      game.scorePopFrames = 0;
+      drawScore();
+      ctx.fillText = origFill;
+      game.score = origScore;
+      game.scorePopFrames = origPop;
+      assert(calls.some(t => t === '00042'),
+        `Expected '00042' in HUD calls, got: ${JSON.stringify(calls)}`);
+      assert(!calls.some(t => t.includes('Score:')),
+        `Expected no 'Score:' prefix, got: ${JSON.stringify(calls)}`);
+    });
+
+    it('HI label appears in HUD when highScore > 0', () => {
+      const calls = [];
+      const origFill = ctx.fillText;
+      ctx.fillText = (text) => calls.push(String(text));
+      const origHS = game.highScore;
+      const origScore = game.score;
+      const origPop = game.scorePopFrames;
+      game.highScore = 150;
+      game.score = 42;
+      game.scorePopFrames = 0;
+      drawScore();
+      ctx.fillText = origFill;
+      game.highScore = origHS;
+      game.score = origScore;
+      game.scorePopFrames = origPop;
+      assert(calls.some(t => t.startsWith('HI ')),
+        `Expected 'HI ...' label in HUD, got: ${JSON.stringify(calls)}`);
+    });
+
+    it('HI label absent when highScore is 0', () => {
+      const calls = [];
+      const origFill = ctx.fillText;
+      ctx.fillText = (text) => calls.push(String(text));
+      const origHS = game.highScore;
+      const origScore = game.score;
+      const origPop = game.scorePopFrames;
+      game.highScore = 0;
+      game.score = 42;
+      game.scorePopFrames = 0;
+      drawScore();
+      ctx.fillText = origFill;
+      game.highScore = origHS;
+      game.score = origScore;
+      game.scorePopFrames = origPop;
+      assert(!calls.some(t => t.startsWith('HI ')),
+        `Expected no 'HI ...' label when highScore is 0, got: ${JSON.stringify(calls)}`);
+    });
+  });
+  ```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+  ```
+  node tests/game.test.js
+  ```
+
+  Expected: the three new tests FAIL (score still renders as `'Score: 42'`, no `HI` label).
+
+- [ ] **Step 3: Implement the new `drawScore`**
+
+  Replace the entire `drawScore` function in `script.js`:
+
+  ```js
+  function drawScore() {
+    const popping = game.scorePopFrames > 0 && isUpdatedMode() && !reducedMotion;
+    if (popping) {
+      // Brief 1.0 → 1.4 ease-out scale around the score's centre on death.
+      const t = game.scorePopFrames / GAME_CONFIG.SCORE_POP_FRAMES; // 1 → 0
+      const scale = 1 + t * 0.4;
+      const cx = canvas.width - GAME_CONFIG.SCORE_X_OFFSET + 30;
+      const cy = GAME_CONFIG.SCORE_Y - 8;
+      ctx.save();
+      ctx.translate(cx, cy);
+      ctx.scale(scale, scale);
+      ctx.translate(-cx, -cy);
+    }
+    const color = game.score >= GAME_CONFIG.DAY_NIGHT_START ? '#ffffff' : '#000000';
+    ctx.fillStyle = color;
+    ctx.font = '20px ' + cfg('SCORE_FONT_FAMILY');
+    ctx.textAlign = 'left';
+    ctx.fillText(
+      String(Math.floor(game.score)).padStart(5, '0'),
+      canvas.width - GAME_CONFIG.SCORE_X_OFFSET,
+      GAME_CONFIG.SCORE_Y
+    );
+    if (game.highScore > 0) {
+      ctx.fillText(
+        'HI ' + String(game.highScore).padStart(5, '0'),
+        canvas.width - GAME_CONFIG.SCORE_X_OFFSET - GAME_CONFIG.SCORE_HI_X_OFFSET,
+        GAME_CONFIG.SCORE_Y
+      );
+    }
+    if (popping) ctx.restore();
+  }
+  ```
+
+  Note: `cx` changed from `+ 50` to `+ 30` to re-centre the pop animation on the shorter 5-digit field.
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+  ```
+  node tests/game.test.js
+  ```
+
+  Expected: all tests pass, including the 3 new ones.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add script.js tests/game.test.js
+  git commit -m "feat(polish): zero-padded score + HI label in HUD"
+  ```
+
+---
+
+### Task 4: Game over screen — format + "Best: 0" gate (TDD)
+
+**Files:**
+- Modify: `script.js:685–701` (`drawGameOverScreen`)
+- Modify: `tests/game.test.js` (add describe block)
+
+- [ ] **Step 1: Write the failing tests**
+
+  Append to `tests/game.test.js`:
+
+  ```js
+  describe('Game over screen (polish pass)', () => {
+    it('score on game over screen is zero-padded', () => {
+      const calls = [];
+      const origFill = ctx.fillText;
+      ctx.fillText = (text) => calls.push(String(text));
+      const origScore = game.score;
+      game.score = 87;
+      drawGameOverScreen();
+      ctx.fillText = origFill;
+      game.score = origScore;
+      assert(calls.some(t => t === '00087'),
+        `Expected '00087' on game over screen, got: ${JSON.stringify(calls)}`);
+      assert(!calls.some(t => t.includes('Score:')),
+        `Expected no 'Score:' prefix on game over screen, got: ${JSON.stringify(calls)}`);
+    });
+
+    it('Best line hidden when highScore is 0', () => {
+      const calls = [];
+      const origFill = ctx.fillText;
+      ctx.fillText = (text) => calls.push(String(text));
+      const origHS = game.highScore;
+      game.highScore = 0;
+      drawGameOverScreen();
+      ctx.fillText = origFill;
+      game.highScore = origHS;
+      assert(!calls.some(t => t.toLowerCase().includes('best')),
+        `Expected no Best line when highScore is 0, got: ${JSON.stringify(calls)}`);
+    });
+
+    it('Best line shown when highScore > 0', () => {
+      const calls = [];
+      const origFill = ctx.fillText;
+      ctx.fillText = (text) => calls.push(String(text));
+      const origHS = game.highScore;
+      game.highScore = 250;
+      drawGameOverScreen();
+      ctx.fillText = origFill;
+      game.highScore = origHS;
+      assert(calls.some(t => t.toLowerCase().includes('best')),
+        `Expected Best line when highScore > 0, got: ${JSON.stringify(calls)}`);
+    });
+  });
+  ```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+  ```
+  node tests/game.test.js
+  ```
+
+  Expected: the 3 new tests FAIL.
+
+- [ ] **Step 3: Implement the updated `drawGameOverScreen`**
+
+  Replace the entire function:
+
+  ```js
+  function drawGameOverScreen() {
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.75)';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+    ctx.fillStyle = 'white';
+    ctx.textAlign = 'center';
+
+    ctx.font = '40px ' + cfg('SCORE_FONT_FAMILY');
+    ctx.fillText('GAME OVER', canvas.width / 2, canvas.height / 2 - 50);
+
+    ctx.font = '20px ' + cfg('SCORE_FONT_FAMILY');
+    ctx.fillText(String(Math.floor(game.score)).padStart(5, '0'), canvas.width / 2, canvas.height / 2 - 10);
+
+    if (game.highScore > 0) {
+      ctx.fillText('BEST: ' + String(game.highScore).padStart(5, '0'), canvas.width / 2, canvas.height / 2 + 20);
+    }
+
+    ctx.font = '16px ' + cfg('SCORE_FONT_FAMILY');
+    ctx.fillText('Tap / Press Space to Restart', canvas.width / 2, canvas.height / 2 + 55);
+  }
+  ```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+  ```
+  node tests/game.test.js
+  ```
+
+  Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add script.js tests/game.test.js
+  git commit -m "feat(polish): game over score zero-padded; hide Best line on first run"
+  ```
+
+---
+
+### Task 5: Extract `getHillColor` helper + interpolate day→night (TDD)
+
+**Files:**
+- Modify: `script.js:543–565` (`drawHills`) — call the new helper
+- Modify: `script.js` — add `getHillColor` immediately before `drawHills`
+- Modify: `script.js:1170+` (Section 10 test exposure) — export `getHillColor`
+- Modify: `tests/game.test.js` (add describe block)
+
+Background: `getBackgroundColor(score)` already mirrors this pattern — check it around line 471 as a reference for style.
+
+- [ ] **Step 1: Write the failing tests**
+
+  Append to `tests/game.test.js`:
+
+  ```js
+  describe('Hill colour interpolation (polish pass)', () => {
+    it('returns HILL_COLOR_DAY below DAY_NIGHT_START', () => {
+      assertEquals(getHillColor(0),   GAME_CONFIG.HILL_COLOR_DAY, 'score 0 → day colour');
+      assertEquals(getHillColor(299), GAME_CONFIG.HILL_COLOR_DAY, 'score 299 → day colour');
+    });
+
+    it('returns HILL_COLOR_NIGHT at or above DAY_NIGHT_END', () => {
+      assertEquals(getHillColor(400),  GAME_CONFIG.HILL_COLOR_NIGHT, 'score 400 → night colour');
+      assertEquals(getHillColor(1000), GAME_CONFIG.HILL_COLOR_NIGHT, 'score 1000 → night colour');
+    });
+
+    it('returns a valid interpolated hex colour in the transition window', () => {
+      const mid = getHillColor(350); // midpoint between 300 and 400
+      assert(mid !== GAME_CONFIG.HILL_COLOR_DAY,   'midpoint should not be day colour');
+      assert(mid !== GAME_CONFIG.HILL_COLOR_NIGHT,  'midpoint should not be night colour');
+      assert(/^#[0-9a-f]{6}$/.test(mid),           'must be a valid lowercase 6-digit hex colour');
+    });
+  });
+  ```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+  ```
+  node tests/game.test.js
+  ```
+
+  Expected: 3 new tests FAIL with "getHillColor is not defined".
+
+- [ ] **Step 3: Add `getHillColor` immediately before `drawHills` (~line 543)**
+
+  Insert this function:
+
+  ```js
+  function getHillColor(score) {
+    if (score < GAME_CONFIG.DAY_NIGHT_START) return GAME_CONFIG.HILL_COLOR_DAY;
+    if (score >= GAME_CONFIG.DAY_NIGHT_END)  return GAME_CONFIG.HILL_COLOR_NIGHT;
+    if (reducedMotion) return GAME_CONFIG.HILL_COLOR_DAY; // snap — stays day until DAY_NIGHT_END
+    const t = (score - GAME_CONFIG.DAY_NIGHT_START) /
+              (GAME_CONFIG.DAY_NIGHT_END - GAME_CONFIG.DAY_NIGHT_START);
+    const parseHex = hex => [
+      parseInt(hex.slice(1, 3), 16),
+      parseInt(hex.slice(3, 5), 16),
+      parseInt(hex.slice(5, 7), 16),
+    ];
+    const day   = parseHex(GAME_CONFIG.HILL_COLOR_DAY);
+    const night = parseHex(GAME_CONFIG.HILL_COLOR_NIGHT);
+    const r = Math.round(day[0] + (night[0] - day[0]) * t);
+    const g = Math.round(day[1] + (night[1] - day[1]) * t);
+    const b = Math.round(day[2] + (night[2] - day[2]) * t);
+    return '#' + [r, g, b].map(v => v.toString(16).padStart(2, '0')).join('');
+  }
+  ```
+
+- [ ] **Step 4: Update `drawHills` to call the helper**
+
+  Replace the colour-selection line in `drawHills`:
+
+  ```js
+  ctx.fillStyle = game.score >= GAME_CONFIG.DAY_NIGHT_START
+    ? GAME_CONFIG.HILL_COLOR_NIGHT
+    : GAME_CONFIG.HILL_COLOR_DAY;
+  ```
+
+  With:
+
+  ```js
+  ctx.fillStyle = getHillColor(game.score);
+  ```
+
+- [ ] **Step 5: Export `getHillColor` in Section 10 (test exposure)**
+
+  Find the block starting with `if (typeof process !== 'undefined'...` near line 1170. Add this line alongside the other `global.getBackgroundColor` export:
+
+  ```js
+  global.getHillColor = getHillColor;
+  ```
+
+- [ ] **Step 6: Run tests to confirm they pass**
+
+  ```
+  node tests/game.test.js
+  ```
+
+  Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+  ```bash
+  git add script.js tests/game.test.js
+  git commit -m "feat(polish): hill colour interpolates smoothly during day→night transition"
+  ```
+
+---
+
+### Task 6: Body background syncs with canvas day/night
+
+**Files:**
+- Modify: `script.js:1037–1053` (WAITING branch of `gameLoop`)
+- Modify: `script.js:1086` (RUNNING branch of `gameLoop`, after `drawBackground()`)
+- Modify: `script.js:978–1007` (`resetGame`)
+
+No test: the Node stub for `document` does not include `document.body`, so a DOM test would require restructuring the stub. Manual verification covers this (checklist at end of plan).
+
+The implementation must guard against the missing `body` in Node — use `if (document.body)`.
+
+- [ ] **Step 1: Add body sync in the WAITING branch**
+
+  The WAITING branch currently reads:
+
+  ```js
+  if (game.state === STATE.WAITING) {
+    game.graceFrames--;
+    if (game.graceFrames <= 0) {
+      game.state = STATE.RUNNING;
+      announce('Go!');
+    }
+    drawBackground();
+    drawHills();
+    ...
+  ```
+
+  Add one line immediately after `drawBackground()`:
+
+  ```js
+    drawBackground();
+    if (document.body) document.body.style.background = getBackgroundColor(game.score);
+    drawHills();
+  ```
+
+- [ ] **Step 2: Add body sync in the RUNNING branch**
+
+  The RUNNING branch calls `drawBackground()` around line 1086. Add the sync line immediately after it:
+
+  ```js
+    drawBackground();
+    if (document.body) document.body.style.background = getBackgroundColor(game.score);
+    runFeatureUpdates();
+  ```
+
+- [ ] **Step 3: Reset the body background in `resetGame`**
+
+  `resetGame` is around line 978. Add this line near the end of the function, after the `announce(...)` call:
+
+  ```js
+    announce('New game. Press space or tap to jump.');
+    if (document.body) document.body.style.background = '';
+  ```
+
+- [ ] **Step 4: Run tests**
+
+  ```
+  node tests/game.test.js
+  ```
+
+  Expected: all tests pass (the guard prevents any exception in Node).
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add script.js
+  git commit -m "feat(polish): page background syncs with canvas day/night colour"
+  ```
+
+---
+
+### Task 7: Dino runs in place during WAITING countdown
+
+**Files:**
+- Modify: `script.js:1038` (WAITING branch of `gameLoop`)
+
+- [ ] **Step 1: Add `game.animFrame++` to the WAITING branch**
+
+  The WAITING branch starts at ~line 1037. Currently:
+
+  ```js
+  if (game.state === STATE.WAITING) {
+    game.graceFrames--;
+    if (game.graceFrames <= 0) {
+  ```
+
+  Change to:
+
+  ```js
+  if (game.state === STATE.WAITING) {
+    game.graceFrames--;
+    game.animFrame++;
+    if (game.graceFrames <= 0) {
+  ```
+
+- [ ] **Step 2: Run tests**
+
+  ```
+  node tests/game.test.js
+  ```
+
+  Expected: all tests pass.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add script.js
+  git commit -m "feat(polish): dino animates during GET READY countdown"
+  ```
+
+---
+
+### Task 8: Regression check + manual playtest
+
+**Files:** none — verification only.
+
+- [ ] **Step 1: Full test suite**
+
+  ```
+  node tests/game.test.js
+  ```
+
+  Expected: all tests pass. Count of tests should be at least 9 more than before this PR (3 HUD format tests + 2 game over tests + 3 hill colour tests + 2 carried-over test-count increase from prior tasks rounding to the describe boundary).
+
+- [ ] **Step 2: Manual playtest checklist** (open `http://localhost:8080` via `npm run serve`)
+
+  - [ ] Score displays as `00000`–`99999` (zero-padded, no "Score: " prefix).
+  - [ ] All canvas text uses monospace font (GET READY, countdown, game over, milestone flash, NEW BEST badge).
+  - [ ] `HI NNNNN` label appears in HUD after the first death; absent on a truly first run (clear localStorage first: `localStorage.clear()` in DevTools → reload).
+  - [ ] Hill colour fades gradually from grey to dark blue between score 300 and 400 (reach score 300+ to verify).
+  - [ ] Page background transitions to dark alongside the canvas during night.
+  - [ ] Refreshing the page (back to WAITING) restores the body background to the CSS default (light grey surround).
+  - [ ] Game over screen hides the "BEST" line on a fresh-localStorage first run; shows it on subsequent runs.
+  - [ ] Dino runs in place during the GET READY countdown (visually animated, not frozen).
+  - [ ] `reducedMotion` (toggle in OS accessibility settings): hill colour snaps at score 400 instead of interpolating; body background still syncs; particles still absent.
+  - [ ] Classic mode: no regressions — font, score format, and micro-fixes apply equally.
+  - [ ] Updated mode at high score (score 300+): sky tint, confetti, speed trail, milestone flash all still work.
+
+- [ ] **Step 3: Push and open PR**
+
+  ```bash
+  git push origin initial-chrome-dino-game
+  ```
+
+  Open a PR from `initial-chrome-dino-game` targeting the repo's default branch. Title suggestion: `feat(polish): HUD redesign, hill interpolation, body sync, micro-fixes (P5)`.

--- a/docs/superpowers/specs/2026-04-25-visible-ux-polish-pass-design.md
+++ b/docs/superpowers/specs/2026-04-25-visible-ux-polish-pass-design.md
@@ -1,0 +1,156 @@
+# Visible UX Polish Pass — Design Spec
+
+**Date:** 2026-04-25
+**Status:** Approved — ready for implementation planning
+**Scope:** Pass 1 of 2. All changes are `script.js`-only. No HTML, CSS, or asset changes required.
+
+---
+
+## Context
+
+PRs #19–22 (P1–P4) completed a polish pass focused on bug fixes, the feature registry, live-tuning, and docs. The game is now feature-rich but has several visible rough edges that affect how it reads and feels to players:
+
+- The HUD only shows the current score; there is no in-game high-score display.
+- All text uses plain `Arial`, which reads as a browser default rather than an arcade game.
+- Score is formatted as `"Score: 42"` — wordy, not arcade-style.
+- Hill colour snaps abruptly during the day→night transition while the sky smoothly interpolates.
+- The page body stays light grey when the canvas goes dark at night, breaking immersion.
+- The game over screen shows "Best: 0" on a player's first run.
+- The dino is completely static during the GET READY countdown.
+
+This pass fixes all seven items in one focused PR.
+
+---
+
+## Section 1 — HUD redesign
+
+### 1a. Font
+
+Replace all hardcoded `'NNpx Arial'` in `script.js` with a monospace stack. Add a single config key:
+
+```js
+SCORE_FONT_FAMILY: "'Courier New', Courier, monospace",
+```
+
+Route it through `cfg('SCORE_FONT_FAMILY')` so it is live-tunable. Every canvas text call — `drawScore`, `drawGetReadyOverlay`, `drawGameOverScreen`, `drawMilestoneFlash`, `drawNewBestBadge` — derives its font family from this key. Only the size part (`'20px'`, `'40px'`, etc.) stays hardcoded per call site.
+
+### 1b. Score format
+
+Drop the `'Score: '` prefix. Display the current score as a zero-padded 5-digit integer:
+
+```js
+String(Math.floor(game.score)).padStart(5, '0')
+```
+
+Range: `00000`–`99999`. Matches the Chrome T-Rex display convention.
+
+### 1c. High-score in HUD
+
+Add a `HI NNNNN` label to the left of the current score in `drawScore()`. Layout:
+
+```
+HI 00312    00487          ← approximate positions
+```
+
+- `HI` label + zero-padded best at `x = canvas.width - SCORE_X_OFFSET - 110` (new config key `SCORE_HI_X_OFFSET = 110`).
+- Current score at `x = canvas.width - SCORE_X_OFFSET` (unchanged).
+- Both labels use the same `game.score >= DAY_NIGHT_START` colour switch already in `drawScore`.
+- The `HI` label is **only rendered when `game.highScore > 0`**. On a first run the right side shows only the current score.
+
+Files touched: `script.js` — `GAME_CONFIG` (2 new keys), `drawScore`.
+
+---
+
+## Section 2 — World visual fixes
+
+### 2a. Hill colour interpolation
+
+`drawHills()` currently selects `HILL_COLOR_DAY` vs `HILL_COLOR_NIGHT` with a hard threshold at `DAY_NIGHT_START` (score 300). The sky (`getBackgroundColor`) smoothly interpolates between score 300 and 400 (`DAY_NIGHT_END`). Hills should match.
+
+Fix: extract the day-to-night interpolation factor `t` and lerp the hill RGB values across the same window:
+
+```js
+// t = 0 at DAY_NIGHT_START, 1 at DAY_NIGHT_END, clamped
+const t = reducedMotion ? (score >= DAY_NIGHT_END ? 1 : 0)
+        : Math.max(0, Math.min(1, (score - DAY_NIGHT_START) / (DAY_NIGHT_END - DAY_NIGHT_START)));
+```
+
+The two hill colour hex strings (`HILL_COLOR_DAY = '#cdcdcd'`, `HILL_COLOR_NIGHT = '#3a3a55'`) are already in `GAME_CONFIG`. Parse them to RGB at draw time, lerp each channel, reconstruct as a hex string. No new config keys needed.
+
+Under `reducedMotion`, snap at `DAY_NIGHT_END` (same behaviour as the background).
+
+Files touched: `script.js` — `drawHills`.
+
+### 2b. Body background sync
+
+The page body (`background-color: #f0f0f0` in `style.css`) stays light grey while the canvas fades to `#1a1a2e` at night, making the canvas look like a floating panel rather than an immersive game.
+
+Fix: one line in the RUNNING branch of `gameLoop` after `drawBackground()`:
+
+```js
+document.body.style.background = getBackgroundColor(game.score);
+```
+
+Reset to `'#ffffff'` in `resetGame()` so a fresh game starts white.
+
+Called once per frame at 60 fps — this is a single style property write, no layout reflow, negligible cost.
+
+Files touched: `script.js` — RUNNING branch of `gameLoop`, `resetGame`.
+
+---
+
+## Section 3 — Micro-fixes
+
+### 3a. Game over "Best: 0"
+
+`drawGameOverScreen()` unconditionally renders `'Best: ' + game.highScore`. On a first run `game.highScore` is 0.
+
+Fix: gate the best line on `game.highScore > 0`. When there is no recorded best, the game over screen shows only GAME OVER, the current score, and the restart prompt.
+
+Files touched: `script.js` — `drawGameOverScreen`.
+
+### 3b. Dino animation in WAITING
+
+During the GET READY countdown, `game.animFrame` is never incremented, so `drawDino()` always renders run-frame 0. The dino is visually frozen.
+
+Fix: add `game.animFrame++` to the WAITING branch of `gameLoop`, immediately after `game.graceFrames--`. The dino will cycle through its two-frame run animation while the countdown ticks.
+
+Files touched: `script.js` — WAITING branch of `gameLoop`.
+
+---
+
+## Architecture summary
+
+All seven changes are confined to `script.js`. No HTML or CSS edits. The changes are grouped into three independently reviewable hunks but small enough to ship in a single PR.
+
+| Hunk | Functions changed | New config keys |
+|---|---|---|
+| HUD redesign | `drawScore` | `SCORE_FONT_FAMILY`, `SCORE_HI_X_OFFSET` |
+| World visual fixes | `drawHills`, `gameLoop` (RUNNING), `resetGame` | none |
+| Micro-fixes | `drawGameOverScreen`, `gameLoop` (WAITING) | none |
+
+---
+
+## Verification checklist
+
+- [ ] Score displays as `00000`–`99999` (zero-padded, no "Score: " prefix).
+- [ ] All canvas text uses the monospace font stack.
+- [ ] `HI NNNNN` appears in HUD after the first run ends; absent on the very first run.
+- [ ] Hill colour fades gradually from grey to dark blue between score 300 and 400.
+- [ ] Page background transitions to dark at night alongside the canvas.
+- [ ] `resetGame()` restores the body background to white.
+- [ ] Game over screen hides "Best" line when high score is 0.
+- [ ] Dino runs in place during the GET READY countdown.
+- [ ] `reducedMotion`: hill colour snaps (no interpolation), body background still syncs.
+- [ ] Classic mode: no regressions — font, score format, and micro-fixes apply equally.
+- [ ] `npm test` passes — no existing tests broken.
+
+---
+
+## Out of scope (Pass 2)
+
+- Tests for `getBackgroundColor` interpolation.
+- Tests for the new HUD high-score rendering.
+- Tests for `audio.land()` and `audio.death()`.
+- Tests for hill colour interpolation.
+- Tests for `announce()`.

--- a/docs/superpowers/specs/2026-04-25-visible-ux-polish-pass-design.md
+++ b/docs/superpowers/specs/2026-04-25-visible-ux-polish-pass-design.md
@@ -75,7 +75,7 @@ const t = reducedMotion ? (score >= DAY_NIGHT_END ? 1 : 0)
         : Math.max(0, Math.min(1, (score - DAY_NIGHT_START) / (DAY_NIGHT_END - DAY_NIGHT_START)));
 ```
 
-The two hill colour hex strings (`HILL_COLOR_DAY = '#cdcdcd'`, `HILL_COLOR_NIGHT = '#3a3a55'`) are already in `GAME_CONFIG`. Parse them to RGB at draw time, lerp each channel, reconstruct as a hex string. No new config keys needed.
+The two hill colour hex strings (`HILL_COLOR_DAY = '#cdcdcd'`, `HILL_COLOR_NIGHT = '#3a3a55'`) are already in `GAME_CONFIG`. Within the transition window (`DAY_NIGHT_START ≤ score < DAY_NIGHT_END`) lerp each RGB channel and reconstruct a hex string. Outside the window use the solid config colour directly — no parsing cost on the vast majority of frames.
 
 Under `reducedMotion`, snap at `DAY_NIGHT_END` (same behaviour as the background).
 
@@ -85,17 +85,21 @@ Files touched: `script.js` — `drawHills`.
 
 The page body (`background-color: #f0f0f0` in `style.css`) stays light grey while the canvas fades to `#1a1a2e` at night, making the canvas look like a floating panel rather than an immersive game.
 
-Fix: one line in the RUNNING branch of `gameLoop` after `drawBackground()`:
+Fix: add one line after `drawBackground()` in **both** the WAITING and RUNNING branches of `gameLoop`:
 
 ```js
 document.body.style.background = getBackgroundColor(game.score);
 ```
 
-Reset to `'#ffffff'` in `resetGame()` so a fresh game starts white.
+In `resetGame()`, clear the inline override entirely so the stylesheet value (`#f0f0f0`) resumes:
 
-Called once per frame at 60 fps — this is a single style property write, no layout reflow, negligible cost.
+```js
+document.body.style.background = '';
+```
 
-Files touched: `script.js` — RUNNING branch of `gameLoop`, `resetGame`.
+Called once per frame at 60 fps — a single style property write, no layout reflow, negligible cost.
+
+Files touched: `script.js` — WAITING + RUNNING branches of `gameLoop`, `resetGame`.
 
 ---
 
@@ -126,7 +130,7 @@ All seven changes are confined to `script.js`. No HTML or CSS edits. The changes
 | Hunk | Functions changed | New config keys |
 |---|---|---|
 | HUD redesign | `drawScore` | `SCORE_FONT_FAMILY`, `SCORE_HI_X_OFFSET` |
-| World visual fixes | `drawHills`, `gameLoop` (RUNNING), `resetGame` | none |
+| World visual fixes | `drawHills`, `gameLoop` (WAITING + RUNNING), `resetGame` | none |
 | Micro-fixes | `drawGameOverScreen`, `gameLoop` (WAITING) | none |
 
 ---

--- a/script.js
+++ b/script.js
@@ -1038,6 +1038,7 @@ function resetGame() {
   initClouds();
   initHills();
   announce('New game. Press space or tap to jump.');
+  if (document.body) document.body.style.background = '';
 }
 
 function gameLoop() {
@@ -1075,6 +1076,7 @@ function gameLoop() {
       announce('Go!');
     }
     drawBackground();
+    if (document.body) document.body.style.background = getBackgroundColor(game.score);
     drawHills();
     drawGround();
     updateClouds();
@@ -1118,6 +1120,7 @@ function gameLoop() {
   }
 
   drawBackground();
+  if (document.body) document.body.style.background = getBackgroundColor(game.score);
   runFeatureUpdates();              // updateHills, updateClouds, updateParticles
   runFeatureDraws('background');    // drawHills, drawClouds
   drawGround();

--- a/script.js
+++ b/script.js
@@ -643,17 +643,29 @@ function drawScore() {
     // Brief 1.0 → 1.4 ease-out scale around the score's centre on death.
     const t = game.scorePopFrames / GAME_CONFIG.SCORE_POP_FRAMES; // 1 → 0
     const scale = 1 + t * 0.4;
-    const cx = canvas.width - GAME_CONFIG.SCORE_X_OFFSET + 50;
+    const cx = canvas.width - GAME_CONFIG.SCORE_X_OFFSET + 30;
     const cy = GAME_CONFIG.SCORE_Y - 8;
     ctx.save();
     ctx.translate(cx, cy);
     ctx.scale(scale, scale);
     ctx.translate(-cx, -cy);
   }
-  ctx.fillStyle = game.score >= GAME_CONFIG.DAY_NIGHT_START ? '#ffffff' : '#000000';
+  const color = game.score >= GAME_CONFIG.DAY_NIGHT_START ? '#ffffff' : '#000000';
+  ctx.fillStyle = color;
   ctx.font = '20px ' + cfg('SCORE_FONT_FAMILY');
   ctx.textAlign = 'left';
-  ctx.fillText('Score: ' + Math.floor(game.score), canvas.width - GAME_CONFIG.SCORE_X_OFFSET, GAME_CONFIG.SCORE_Y);
+  ctx.fillText(
+    String(Math.floor(game.score)).padStart(5, '0'),
+    canvas.width - GAME_CONFIG.SCORE_X_OFFSET,
+    GAME_CONFIG.SCORE_Y
+  );
+  if (game.highScore > 0) {
+    ctx.fillText(
+      'HI ' + String(game.highScore).padStart(5, '0'),
+      canvas.width - GAME_CONFIG.SCORE_X_OFFSET - GAME_CONFIG.SCORE_HI_X_OFFSET,
+      GAME_CONFIG.SCORE_Y
+    );
+  }
   if (popping) ctx.restore();
 }
 

--- a/script.js
+++ b/script.js
@@ -156,8 +156,10 @@ const GAME_CONFIG = Object.freeze({
   NEW_BEST_FRAMES:        120,
 
   // --- HUD ---
-  SCORE_X_OFFSET:         150,    // pixels from right edge
+  SCORE_X_OFFSET:         150,    // pixels from right edge for the current-score label
   SCORE_Y:                 30,
+  SCORE_HI_X_OFFSET:      110,    // additional px left of SCORE_X_OFFSET for the HI label
+  SCORE_FONT_FAMILY:      "'Courier New', Courier, monospace",
 
   // --- Animation ---
   RUN_FRAME_PERIOD:        10,    // swap run-cycle sprite every N frames (~167 ms @ 60 fps)

--- a/script.js
+++ b/script.js
@@ -707,8 +707,11 @@ function drawGameOverScreen() {
   ctx.fillText('GAME OVER', canvas.width / 2, canvas.height / 2 - 50);
 
   ctx.font = '20px ' + cfg('SCORE_FONT_FAMILY');
-  ctx.fillText('Score: ' + Math.floor(game.score), canvas.width / 2, canvas.height / 2 - 10);
-  ctx.fillText('Best: ' + game.highScore, canvas.width / 2, canvas.height / 2 + 20);
+  ctx.fillText(String(Math.floor(game.score)).padStart(5, '0'), canvas.width / 2, canvas.height / 2 - 10);
+
+  if (game.highScore > 0) {
+    ctx.fillText('BEST: ' + String(game.highScore).padStart(5, '0'), canvas.width / 2, canvas.height / 2 + 20);
+  }
 
   ctx.font = '16px ' + cfg('SCORE_FONT_FAMILY');
   ctx.fillText('Tap / Press Space to Restart', canvas.width / 2, canvas.height / 2 + 55);

--- a/script.js
+++ b/script.js
@@ -651,7 +651,7 @@ function drawScore() {
     ctx.translate(-cx, -cy);
   }
   ctx.fillStyle = game.score >= GAME_CONFIG.DAY_NIGHT_START ? '#ffffff' : '#000000';
-  ctx.font = '20px Arial';
+  ctx.font = '20px ' + cfg('SCORE_FONT_FAMILY');
   ctx.textAlign = 'left';
   ctx.fillText('Score: ' + Math.floor(game.score), canvas.width - GAME_CONFIG.SCORE_X_OFFSET, GAME_CONFIG.SCORE_Y);
   if (popping) ctx.restore();
@@ -672,14 +672,14 @@ function drawGetReadyOverlay() {
   ctx.textAlign = 'center';
   ctx.fillStyle = 'rgba(0,0,0,0.55)';
   if (game.graceFrames > GAME_CONFIG.GRACE_FRAMES * 0.33) {
-    ctx.font = '28px Arial';
+    ctx.font = '28px ' + cfg('SCORE_FONT_FAMILY');
     ctx.fillText('GET READY', canvas.width / 2, canvas.height / 2 - 10);
-    ctx.font = '14px Arial';
+    ctx.font = '14px ' + cfg('SCORE_FONT_FAMILY');
     ctx.fillText('Press Space / Tap to jump', canvas.width / 2, canvas.height / 2 + 16);
   } else {
     const step = Math.ceil(GAME_CONFIG.GRACE_FRAMES / 9);
     const count = Math.ceil(game.graceFrames / step);
-    ctx.font = '48px Arial';
+    ctx.font = '48px ' + cfg('SCORE_FONT_FAMILY');
     ctx.fillText(count || 'GO!', canvas.width / 2, canvas.height / 2 + 16);
   }
 }
@@ -691,14 +691,14 @@ function drawGameOverScreen() {
   ctx.fillStyle = 'white';
   ctx.textAlign = 'center';
 
-  ctx.font = '40px Arial';
+  ctx.font = '40px ' + cfg('SCORE_FONT_FAMILY');
   ctx.fillText('GAME OVER', canvas.width / 2, canvas.height / 2 - 50);
 
-  ctx.font = '20px Arial';
+  ctx.font = '20px ' + cfg('SCORE_FONT_FAMILY');
   ctx.fillText('Score: ' + Math.floor(game.score), canvas.width / 2, canvas.height / 2 - 10);
   ctx.fillText('Best: ' + game.highScore, canvas.width / 2, canvas.height / 2 + 20);
 
-  ctx.font = '16px Arial';
+  ctx.font = '16px ' + cfg('SCORE_FONT_FAMILY');
   ctx.fillText('Tap / Press Space to Restart', canvas.width / 2, canvas.height / 2 + 55);
 }
 
@@ -708,7 +708,7 @@ function drawMilestoneFlash() {
   ctx.globalAlpha = game.milestoneFrames / GAME_CONFIG.MILESTONE_FRAMES;
   ctx.fillStyle = game.score >= GAME_CONFIG.DAY_NIGHT_START ? '#ffffff' : '#000000';
   ctx.textAlign = 'center';
-  ctx.font = 'bold 22px Arial';
+  ctx.font = 'bold 22px ' + cfg('SCORE_FONT_FAMILY');
   ctx.fillText(game.milestoneText, canvas.width / 2, canvas.height / 2 - 30);
   ctx.restore();
   game.milestoneFrames--;
@@ -720,7 +720,7 @@ function drawNewBestBadge() {
   ctx.globalAlpha = game.newBestFrames / GAME_CONFIG.NEW_BEST_FRAMES;
   ctx.fillStyle = '#ffd700';
   ctx.textAlign = 'left';
-  ctx.font = 'bold 14px Arial';
+  ctx.font = 'bold 14px ' + cfg('SCORE_FONT_FAMILY');
   // Drop below the milestone flash when both fire on the same frame
   // (level-up + new-best at score = highScore + 100).
   const y = game.milestoneFrames > 0 ? 100 : 70;

--- a/script.js
+++ b/script.js
@@ -1082,7 +1082,7 @@ function gameLoop() {
     game.milestoneText = 'LEVEL ' + (level + 1);
     game.milestoneFrames = GAME_CONFIG.MILESTONE_FRAMES;
     audio.milestone();
-    emitParticles('confetti', canvas.width - GAME_CONFIG.SCORE_X_OFFSET + 50, GAME_CONFIG.SCORE_Y);
+    emitParticles('confetti', canvas.width - GAME_CONFIG.SCORE_X_OFFSET + 30, GAME_CONFIG.SCORE_Y);
   }
 
   // Scroll ground.

--- a/script.js
+++ b/script.js
@@ -542,12 +542,29 @@ function updateHills() {
   }
 }
 
+function getHillColor(score) {
+  if (score < GAME_CONFIG.DAY_NIGHT_START) return GAME_CONFIG.HILL_COLOR_DAY;
+  if (score >= GAME_CONFIG.DAY_NIGHT_END)  return GAME_CONFIG.HILL_COLOR_NIGHT;
+  if (reducedMotion) return GAME_CONFIG.HILL_COLOR_DAY; // snap — stays day until DAY_NIGHT_END
+  const t = (score - GAME_CONFIG.DAY_NIGHT_START) /
+            (GAME_CONFIG.DAY_NIGHT_END - GAME_CONFIG.DAY_NIGHT_START);
+  const parseHex = hex => [
+    parseInt(hex.slice(1, 3), 16),
+    parseInt(hex.slice(3, 5), 16),
+    parseInt(hex.slice(5, 7), 16),
+  ];
+  const day   = parseHex(GAME_CONFIG.HILL_COLOR_DAY);
+  const night = parseHex(GAME_CONFIG.HILL_COLOR_NIGHT);
+  const r = Math.round(day[0] + (night[0] - day[0]) * t);
+  const g = Math.round(day[1] + (night[1] - day[1]) * t);
+  const b = Math.round(day[2] + (night[2] - day[2]) * t);
+  return '#' + [r, g, b].map(v => v.toString(16).padStart(2, '0')).join('');
+}
+
 function drawHills() {
   if (!isUpdatedMode() || game.hills.length === 0) return;
   // Pick a colour that contrasts with the day/night background.
-  ctx.fillStyle = game.score >= GAME_CONFIG.DAY_NIGHT_START
-    ? GAME_CONFIG.HILL_COLOR_NIGHT
-    : GAME_CONFIG.HILL_COLOR_DAY;
+  ctx.fillStyle = getHillColor(game.score);
   const baseY = canvas.height - 16;
   for (const hill of game.hills) {
     if (typeof ctx.ellipse !== 'function') {
@@ -1192,6 +1209,7 @@ if (typeof process !== 'undefined' && process.versions && process.versions.node)
   global.ctx = ctx;
   global.dino = dino;
   global.getBackgroundColor = getBackgroundColor;
+  global.getHillColor = getHillColor;
   global.drawBackground = drawBackground;
   global.initClouds = initClouds;
   global.updateClouds = updateClouds;

--- a/script.js
+++ b/script.js
@@ -1071,6 +1071,7 @@ function gameLoop() {
   // WAITING — grace-period countdown with GET READY overlay.
   if (game.state === STATE.WAITING) {
     game.graceFrames--;
+    game.animFrame++;
     if (game.graceFrames <= 0) {
       game.state = STATE.RUNNING;
       announce('Go!');

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -1088,12 +1088,15 @@ describe('HUD score format (polish pass)', () => {
     ctx.fillText = (text) => calls.push(String(text));
     const origScore = game.score;
     const origPop = game.scorePopFrames;
+    const origHS = game.highScore;
     game.score = 42;
     game.scorePopFrames = 0;
+    game.highScore = 0;
     drawScore();
     ctx.fillText = origFill;
     game.score = origScore;
     game.scorePopFrames = origPop;
+    game.highScore = origHS;
     assert(calls.some(t => t === '00042'),
       `Expected '00042' in HUD calls, got: ${JSON.stringify(calls)}`);
     assert(!calls.some(t => t.includes('Score:')),

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -1142,6 +1142,49 @@ describe('HUD score format (polish pass)', () => {
   });
 });
 
+describe('Game over screen (polish pass)', () => {
+  it('score on game over screen is zero-padded without "Score:" prefix', () => {
+    const calls = [];
+    const origFill = ctx.fillText;
+    ctx.fillText = (text) => calls.push(String(text));
+    const origScore = game.score;
+    game.score = 87;
+    drawGameOverScreen();
+    ctx.fillText = origFill;
+    game.score = origScore;
+    assert(calls.some(t => t === '00087'),
+      `Expected '00087' on game over screen, got: ${JSON.stringify(calls)}`);
+    assert(!calls.some(t => t.includes('Score:')),
+      `Expected no 'Score:' prefix on game over screen, got: ${JSON.stringify(calls)}`);
+  });
+
+  it('Best line hidden when highScore is 0', () => {
+    const calls = [];
+    const origFill = ctx.fillText;
+    ctx.fillText = (text) => calls.push(String(text));
+    const origHS = game.highScore;
+    game.highScore = 0;
+    drawGameOverScreen();
+    ctx.fillText = origFill;
+    game.highScore = origHS;
+    assert(!calls.some(t => t.toLowerCase().includes('best')),
+      `Expected no Best line when highScore is 0, got: ${JSON.stringify(calls)}`);
+  });
+
+  it('Best line shown when highScore > 0', () => {
+    const calls = [];
+    const origFill = ctx.fillText;
+    ctx.fillText = (text) => calls.push(String(text));
+    const origHS = game.highScore;
+    game.highScore = 250;
+    drawGameOverScreen();
+    ctx.fillText = origFill;
+    game.highScore = origHS;
+    assert(calls.some(t => t.toLowerCase().includes('best')),
+      `Expected Best line when highScore > 0, got: ${JSON.stringify(calls)}`);
+  });
+});
+
 // --- Test Summary ---
 // Print summary both in the browser (on window.onload) and in Node (via a
 // setTimeout fallback so async tests have time to complete).

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -1081,6 +1081,64 @@ describe('Live-tuning hook (PR-P3)', () => {
   });
 });
 
+describe('HUD score format (polish pass)', () => {
+  it('score renders as zero-padded 5-digit string without "Score:" prefix', () => {
+    const calls = [];
+    const origFill = ctx.fillText;
+    ctx.fillText = (text) => calls.push(String(text));
+    const origScore = game.score;
+    const origPop = game.scorePopFrames;
+    game.score = 42;
+    game.scorePopFrames = 0;
+    drawScore();
+    ctx.fillText = origFill;
+    game.score = origScore;
+    game.scorePopFrames = origPop;
+    assert(calls.some(t => t === '00042'),
+      `Expected '00042' in HUD calls, got: ${JSON.stringify(calls)}`);
+    assert(!calls.some(t => t.includes('Score:')),
+      `Expected no 'Score:' prefix, got: ${JSON.stringify(calls)}`);
+  });
+
+  it('HI label appears in HUD when highScore > 0', () => {
+    const calls = [];
+    const origFill = ctx.fillText;
+    ctx.fillText = (text) => calls.push(String(text));
+    const origHS = game.highScore;
+    const origScore = game.score;
+    const origPop = game.scorePopFrames;
+    game.highScore = 150;
+    game.score = 42;
+    game.scorePopFrames = 0;
+    drawScore();
+    ctx.fillText = origFill;
+    game.highScore = origHS;
+    game.score = origScore;
+    game.scorePopFrames = origPop;
+    assert(calls.some(t => t.startsWith('HI ')),
+      `Expected 'HI ...' label in HUD, got: ${JSON.stringify(calls)}`);
+  });
+
+  it('HI label absent when highScore is 0', () => {
+    const calls = [];
+    const origFill = ctx.fillText;
+    ctx.fillText = (text) => calls.push(String(text));
+    const origHS = game.highScore;
+    const origScore = game.score;
+    const origPop = game.scorePopFrames;
+    game.highScore = 0;
+    game.score = 42;
+    game.scorePopFrames = 0;
+    drawScore();
+    ctx.fillText = origFill;
+    game.highScore = origHS;
+    game.score = origScore;
+    game.scorePopFrames = origPop;
+    assert(!calls.some(t => t.startsWith('HI ')),
+      `Expected no 'HI ...' label when highScore is 0, got: ${JSON.stringify(calls)}`);
+  });
+});
+
 // --- Test Summary ---
 // Print summary both in the browser (on window.onload) and in Node (via a
 // setTimeout fallback so async tests have time to complete).

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -1202,6 +1202,18 @@ function printSummary() {
   console.log(`--------------------`);
 }
 
+describe('Dino animation in WAITING state (polish pass)', () => {
+  it('increments animFrame each frame during GET READY countdown', () => {
+    resetGame();
+    game.graceFrames = 2; // ensure graceFrames stays > 0 after one decrement
+    const before = game.animFrame;
+    gameLoop();
+    cancelAnimationFrame(game.animationFrameId);
+    assertEquals(game.animFrame, before + 1, 'animFrame should increment by 1 per WAITING frame');
+    assertEquals(game.state, STATE.WAITING, 'state should remain WAITING when graceFrames > 0');
+  });
+});
+
 describe('Hill colour interpolation (polish pass)', () => {
   it('returns HILL_COLOR_DAY below DAY_NIGHT_START', () => {
     assertEquals(getHillColor(0),   GAME_CONFIG.HILL_COLOR_DAY, 'score 0 → day colour');

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -1202,6 +1202,25 @@ function printSummary() {
   console.log(`--------------------`);
 }
 
+describe('Hill colour interpolation (polish pass)', () => {
+  it('returns HILL_COLOR_DAY below DAY_NIGHT_START', () => {
+    assertEquals(getHillColor(0),   GAME_CONFIG.HILL_COLOR_DAY, 'score 0 → day colour');
+    assertEquals(getHillColor(299), GAME_CONFIG.HILL_COLOR_DAY, 'score 299 → day colour');
+  });
+
+  it('returns HILL_COLOR_NIGHT at or above DAY_NIGHT_END', () => {
+    assertEquals(getHillColor(400),  GAME_CONFIG.HILL_COLOR_NIGHT, 'score 400 → night colour');
+    assertEquals(getHillColor(1000), GAME_CONFIG.HILL_COLOR_NIGHT, 'score 1000 → night colour');
+  });
+
+  it('returns a valid interpolated hex colour in the transition window', () => {
+    const mid = getHillColor(350); // midpoint between 300 and 400
+    assert(mid !== GAME_CONFIG.HILL_COLOR_DAY,   'midpoint should not be day colour');
+    assert(mid !== GAME_CONFIG.HILL_COLOR_NIGHT,  'midpoint should not be night colour');
+    assert(/^#[0-9a-f]{6}$/.test(mid),           'must be a valid lowercase 6-digit hex colour');
+  });
+});
+
 if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
   window.addEventListener('load', () => setTimeout(printSummary, 500));
 } else {


### PR DESCRIPTION
## Summary

- **HUD redesign** — score displays as zero-padded 5-digit integer (`00042`), all canvas text switched from `Arial` to a monospace stack (`'Courier New', Courier, monospace`) via live-tunable `SCORE_FONT_FAMILY` config key, and a `HI NNNNN` label appears left of the score after the first run ends (hidden on first run)
- **World visual fixes** — hill colour now interpolates smoothly from grey to dark blue across score 300–400 (matching the sky), and the page body background syncs with the canvas day/night colour so the canvas no longer looks like a floating panel at night
- **Micro-fixes** — game over screen hides the "Best" line when `highScore === 0` (no more "Best: 0" on first run), and the dino runs in place during the GET READY countdown instead of being frozen

## Test plan

- [ ] Score renders as `00000`–`99999` with no "Score: " prefix
- [ ] All canvas text uses monospace font (HUD, game over, milestone flash, new best badge, get ready overlay)
- [ ] `HI NNNNN` appears in HUD after completing the first run; absent on very first run
- [ ] Hill colour fades gradually between score 300 and 400 (not a hard snap)
- [ ] Page background transitions to dark blue at night alongside the canvas
- [ ] `resetGame()` restores the body background (light grey returns)
- [ ] Game over screen shows no "Best" line on first run; shows `BEST: 00042` after a recorded run
- [ ] Dino runs in place during GET READY countdown
- [ ] `reducedMotion`: hill colour snaps at score 400, body background still syncs
- [ ] `npm test` (88 tests, 0 failures)