### PR TITLE
P6: test coverage gap fill

### DIFF
--- a/docs/superpowers/plans/2026-04-25-test-coverage-gap-fill.md
+++ b/docs/superpowers/plans/2026-04-25-test-coverage-gap-fill.md
@@ -1,0 +1,344 @@
+# Test Coverage Gap Fill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fill the three test coverage gaps deferred from the visible UX polish pass (P5): `announce()` tests, `getBackgroundColor` boundary test, and dedicated `audio.land()` / `audio.death()` short-circuit tests.
+
+**Architecture:** Two files change — `script.js` gains a 2-line export addition so `announce` and `a11yLive` are reachable from tests; `tests/game.test.js` gains 7 new tests spread across three existing describe blocks and one new one. No logic changes in `script.js`.
+
+**Tech Stack:** Vanilla JS, custom Node test harness (`describe`/`it`/`assert`/`assertEquals`). Node binary: `"C:\Users\snehi\AppData\Local\Programs\cursor\resources\app\resources\helpers\node.exe"` (standard `node` is not in PATH on this machine).
+
+---
+
+## File map
+
+| File | Change |
+|---|---|
+| `script.js` | Add 2 lines to the Node exports block (lines 1217–1218 area) |
+| `tests/game.test.js` | Task 1: new `announce()` describe block (2 tests). Task 2: 1 test inside `Day/Night Cycle`. Task 3: 4 tests inside `Audio (PR-B)`. |
+
+---
+
+## Task 1: Export `announce` + `a11yLive` and add `announce()` tests
+
+**Files:**
+- Modify: `script.js` (Node exports block, after line 1217)
+- Modify: `tests/game.test.js` (new describe block before `// --- Test Summary ---` comment)
+
+### Context
+
+`announce()` writes a screen-reader message to `a11yLive.textContent`. Neither is exported, so tests cannot observe the side effect today. The fix is two export lines in `script.js`, plus two tests.
+
+In Node, `a11yLive` is the stub object returned by `document.getElementById('a11y-live')`:
+```js
+{ addEventListener: () => {}, setAttribute: () => {}, dataset: {}, textContent: '' }
+```
+`textContent` is a writable plain property, so `announce('hello')` sets it to `'hello'` and we can read it back.
+
+---
+
+- [ ] **Step 1: Write the two failing tests**
+
+Append this describe block to `tests/game.test.js`, immediately before the `// --- Test Summary ---` comment (which currently starts at line 1083):
+
+```js
+describe('announce() accessibility helper', () => {
+  it('sets a11yLive.textContent to the announced message', () => {
+    announce('hello');
+    assertEquals(a11yLive.textContent, 'hello',
+      'announce should write message to a11y live region');
+  });
+
+  it('overwrites textContent on repeated calls', () => {
+    announce('first');
+    announce('second');
+    assertEquals(a11yLive.textContent, 'second',
+      'second announce should overwrite the first');
+  });
+});
+
+```
+
+- [ ] **Step 2: Run to verify both tests fail**
+
+```bash
+"C:\Users\snehi\AppData\Local\Programs\cursor\resources\app\resources\helpers\node.exe" tests/game.test.js 2>&1 | grep -A2 "announce"
+```
+
+Expected output contains:
+```
+FAILED: sets a11yLive.textContent to the announced message
+FAILED: overwrites textContent on repeated calls
+```
+(Both fail with `ReferenceError: announce is not defined` because the export hasn't been added yet.)
+
+- [ ] **Step 3: Add the two export lines to `script.js`**
+
+Find the end of the Node exports block. The last two lines currently are:
+```js
+  global.loadTuning = loadTuning;
+  global.saveTuning = saveTuning;
+```
+
+Add immediately after `global.saveTuning = saveTuning;`:
+```js
+  global.announce  = announce;
+  global.a11yLive  = a11yLive;
+```
+
+The block should look like this after the edit:
+```js
+  global.cfg = cfg;
+  global.loadTuning = loadTuning;
+  global.saveTuning = saveTuning;
+  global.announce  = announce;
+  global.a11yLive  = a11yLive;
+```
+
+- [ ] **Step 4: Run tests and verify both pass**
+
+```bash
+"C:\Users\snehi\AppData\Local\Programs\cursor\resources\app\resources\helpers\node.exe" tests/game.test.js 2>&1 | grep -A1 "announce"
+```
+
+Expected output contains:
+```
+announce() accessibility helper
+  PASSED: sets a11yLive.textContent to the announced message
+  PASSED: overwrites textContent on repeated calls
+```
+
+- [ ] **Step 5: Verify no regressions**
+
+```bash
+"C:\Users\snehi\AppData\Local\Programs\cursor\resources\app\resources\helpers\node.exe" tests/game.test.js 2>&1 | tail -6
+```
+
+Expected:
+```
+Total tests: 80
+Passed: 80
+All tests passed!
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add script.js tests/game.test.js
+git commit -m "test(coverage): export announce+a11yLive and add announce() tests"
+```
+
+---
+
+## Task 2: `getBackgroundColor` boundary test at DAY_NIGHT_START
+
+**Files:**
+- Modify: `tests/game.test.js` (inside existing `Day/Night Cycle` describe block)
+
+### Context
+
+The existing tests cover score 0 (`#ffffff`), score 350 (`#8d8d97`), and score 400 (`#1a1a2e`). Score 300 is the boundary where the interpolation window begins. The code path is:
+
+```js
+// s < DAY_NIGHT_START (300) → returns '#ffffff' directly
+// s >= DAY_NIGHT_END  (400) → returns '#1a1a2e' directly
+// else: t = (s - 300) / (400 - 300) → interpolate
+```
+
+At score 300, `s < DAY_NIGHT_START` is `300 < 300` = false, so it falls through to interpolation with `t = 0`. At `t = 0`: `r = g = 255`, `b = 255` → `'#ffffff'`. This boundary pin guards against a future off-by-one breaking the transition start.
+
+---
+
+- [ ] **Step 1: Add the boundary test inside the existing `Day/Night Cycle` describe block**
+
+Find this closing line in `tests/game.test.js`:
+```js
+  it('should return the correct interpolated color at score 350', () => {
+    assertEquals(getBackgroundColor(350), '#8d8d97',
+      `Score 350 (t=0.5) should produce midpoint color #8d8d97`);
+  });
+```
+
+Insert the new test immediately after it (before the `it('should initialise stars...')` test):
+
+```js
+  it('returns #ffffff at DAY_NIGHT_START (score 300, t=0 boundary)', () => {
+    assertEquals(getBackgroundColor(300), '#ffffff',
+      'Score 300 is the first frame of the interpolation window — t=0 still produces white');
+  });
+
+```
+
+- [ ] **Step 2: Run and verify the new test passes**
+
+```bash
+"C:\Users\snehi\AppData\Local\Programs\cursor\resources\app\resources\helpers\node.exe" tests/game.test.js 2>&1 | grep "DAY_NIGHT_START\|score 300"
+```
+
+Expected:
+```
+  PASSED: returns #ffffff at DAY_NIGHT_START (score 300, t=0 boundary)
+```
+
+- [ ] **Step 3: Verify no regressions**
+
+```bash
+"C:\Users\snehi\AppData\Local\Programs\cursor\resources\app\resources\helpers\node.exe" tests/game.test.js 2>&1 | tail -6
+```
+
+Expected:
+```
+Total tests: 81
+Passed: 81
+All tests passed!
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/game.test.js
+git commit -m "test(coverage): pin getBackgroundColor boundary at DAY_NIGHT_START"
+```
+
+---
+
+## Task 3: `audio.land()` and `audio.death()` short-circuit tests
+
+**Files:**
+- Modify: `tests/game.test.js` (inside existing `Audio (PR-B)` describe block)
+
+### Context
+
+`audio.land()` calls `this.blip()`, which has `if (this.muted || !isUpdatedMode()) return` before it ever calls `this.ensure()`. `audio.death()` has the same guard directly: `if (this.muted || !isUpdatedMode()) return`. Both functions are already called in the existing "does not throw" bundle test, but neither has an isolated short-circuit test. The pattern to follow is the existing `audio.jump()` spy tests.
+
+The spy technique: temporarily replace `audio.ensure` with a counting function, call the audio method, restore `audio.ensure`, assert the count is 0.
+
+---
+
+- [ ] **Step 1: Add 4 tests inside the existing `Audio (PR-B)` describe block**
+
+Find the closing `});` of the `Audio (PR-B)` block (currently after the `audio.jump() does not call ctx oscillator when muted` test, around line 503). Insert these 4 tests before that closing `});`:
+
+```js
+  it('audio.land() does not call ensure() in classic mode', () => {
+    setMode(MODES.CLASSIC);
+    cancelAnimationFrame(game.animationFrameId);
+    audio.setMuted(false);
+    let ensureCalls = 0;
+    const originalEnsure = audio.ensure;
+    audio.ensure = function () { ensureCalls++; return null; };
+    audio.land();
+    audio.ensure = originalEnsure;
+    assertEquals(ensureCalls, 0, 'Classic mode: land() should not reach ensure()');
+    setMode(MODES.UPDATED);
+    cancelAnimationFrame(game.animationFrameId);
+  });
+
+  it('audio.land() does not call ensure() when muted', () => {
+    setMode(MODES.UPDATED);
+    cancelAnimationFrame(game.animationFrameId);
+    audio.setMuted(true);
+    let ensureCalls = 0;
+    const originalEnsure = audio.ensure;
+    audio.ensure = function () { ensureCalls++; return null; };
+    audio.land();
+    audio.ensure = originalEnsure;
+    assertEquals(ensureCalls, 0, 'Muted: land() should not reach ensure()');
+    audio.setMuted(false);
+  });
+
+  it('audio.death() does not call ensure() in classic mode', () => {
+    setMode(MODES.CLASSIC);
+    cancelAnimationFrame(game.animationFrameId);
+    audio.setMuted(false);
+    let ensureCalls = 0;
+    const originalEnsure = audio.ensure;
+    audio.ensure = function () { ensureCalls++; return null; };
+    audio.death();
+    audio.ensure = originalEnsure;
+    assertEquals(ensureCalls, 0, 'Classic mode: death() should not reach ensure()');
+    setMode(MODES.UPDATED);
+    cancelAnimationFrame(game.animationFrameId);
+  });
+
+  it('audio.death() does not call ensure() when muted', () => {
+    setMode(MODES.UPDATED);
+    cancelAnimationFrame(game.animationFrameId);
+    audio.setMuted(true);
+    let ensureCalls = 0;
+    const originalEnsure = audio.ensure;
+    audio.ensure = function () { ensureCalls++; return null; };
+    audio.death();
+    audio.ensure = originalEnsure;
+    assertEquals(ensureCalls, 0, 'Muted: death() should not reach ensure()');
+    audio.setMuted(false);
+  });
+
+```
+
+- [ ] **Step 2: Run and verify all 4 new tests pass**
+
+```bash
+"C:\Users\snehi\AppData\Local\Programs\cursor\resources\app\resources\helpers\node.exe" tests/game.test.js 2>&1 | grep "land\|death"
+```
+
+Expected output contains all four:
+```
+  PASSED: audio.land() does not call ensure() in classic mode
+  PASSED: audio.land() does not call ensure() when muted
+  PASSED: audio.death() does not call ensure() in classic mode
+  PASSED: audio.death() does not call ensure() when muted
+```
+
+- [ ] **Step 3: Verify no regressions**
+
+```bash
+"C:\Users\snehi\AppData\Local\Programs\cursor\resources\app\resources\helpers\node.exe" tests/game.test.js 2>&1 | tail -6
+```
+
+Expected:
+```
+Total tests: 85
+Passed: 85
+All tests passed!
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/game.test.js
+git commit -m "test(coverage): dedicated short-circuit tests for audio.land() and audio.death()"
+```
+
+---
+
+## Task 4: Regression check
+
+**Files:** none (read-only verification)
+
+- [ ] **Step 1: Run the full test suite**
+
+```bash
+"C:\Users\snehi\AppData\Local\Programs\cursor\resources\app\resources\helpers\node.exe" tests/game.test.js 2>&1
+```
+
+Expected final lines:
+```
+Total tests: 85
+Passed: 85
+All tests passed!
+```
+
+If the test count differs from 85, count the new tests manually: 2 (announce) + 1 (getBackgroundColor boundary) + 4 (audio.land/death) = 7 additions over the 78-test baseline. If the base branch already includes the P5 merge (88 tests), the expected count is 95.
+
+- [ ] **Step 2: Verify all spec items are covered**
+
+Check each item from the verification checklist in `docs/superpowers/specs/2026-04-25-test-coverage-gap-fill-design.md`:
+- `getBackgroundColor(300)` returns `'#ffffff'` — covered by Task 2
+- `audio.land()` does not call `ensure()` in classic mode — covered by Task 3
+- `audio.land()` does not call `ensure()` when muted — covered by Task 3
+- `audio.death()` does not call `ensure()` in classic mode — covered by Task 3
+- `audio.death()` does not call `ensure()` when muted — covered by Task 3
+- `announce('hello')` sets `a11yLive.textContent` to `'hello'` — covered by Task 1
+- `announce('world')` overwrites to `'world'` — covered by Task 1
+- No existing tests broken — confirmed by full suite pass

--- a/docs/superpowers/specs/2026-04-25-test-coverage-gap-fill-design.md
+++ b/docs/superpowers/specs/2026-04-25-test-coverage-gap-fill-design.md
@@ -1,0 +1,127 @@
+# Test Coverage Gap Fill — Design Spec
+
+**Date:** 2026-04-25
+**Status:** Approved — ready for implementation planning
+**Scope:** Pass 2 of 2. Fills the three test coverage gaps left out-of-scope by the visible UX polish pass (P5/PR #23). All changes are `script.js` (2-line export addition) and `tests/game.test.js` only.
+
+---
+
+## Context
+
+PRs #19–23 completed a bug-fix pass (P1), feature registry (P2), live-tuning (P3), docs (P4), and visible UX polish (P5). The P5 spec explicitly deferred five test items to this pass. Two of those were completed as part of P5 implementation (HUD high-score rendering tests, hill colour interpolation tests). Three remain:
+
+- `getBackgroundColor` interpolation — boundary and `reducedMotion` paths untested.
+- `audio.land()` and `audio.death()` — short-circuit behaviours only covered by a "does not throw" bundle test, not individually.
+- `announce()` — no tests; not exported.
+
+---
+
+## Section 1 — `getBackgroundColor` interpolation
+
+**Existing coverage:** score 0 (`#ffffff`), score 350 (`#8d8d97`), score 400 (`#1a1a2e`), and stars-init at score 400.
+
+**Gaps:**
+
+### 1a. Boundary at DAY_NIGHT_START (score 300)
+
+The formula uses `if (s < DAY_NIGHT_START) return '#ffffff'`, so score exactly 300 falls through to the interpolation path with `t = 0`. At `t = 0` the channels are `r = g = 255`, `b = 255`, which produces `#ffffff`. This is worth pinning as an explicit boundary regression guard.
+
+Test: `getBackgroundColor(300) === '#ffffff'`
+
+### 1b. reducedMotion snap
+
+Under `reducedMotion`, the function returns `'#ffffff'` for any score in the `[DAY_NIGHT_START, DAY_NIGHT_END)` window (no interpolation), and `'#1a1a2e'` for score ≥ `DAY_NIGHT_END`. Currently no test exercises the `reducedMotion` path.
+
+Tests:
+- `getBackgroundColor(350)` under `reducedMotion = true` returns `'#ffffff'`
+- `getBackgroundColor(400)` under `reducedMotion = true` returns `'#1a1a2e'`
+
+**Note on `reducedMotion`:** It is a module-level `const` read once from `window.matchMedia`. In Node the stub returns `{ matches: false }`, so `reducedMotion === false` by default. Tests must temporarily set `global.reducedMotion = true` before the call and restore it after.
+
+**Wait — `reducedMotion` is a `const`.** It cannot be reassigned. The correct approach is to replace the `const` declaration with a `let` in `script.js` **or** export it so tests can verify the snap behaviour through a different angle.
+
+**Resolution:** Do not change the `const`. Instead, test the `reducedMotion` snap indirectly through `getHillColor`, which was already extracted as a pure function that accepts `score` and reads `reducedMotion` internally. Since `reducedMotion` cannot be overridden in Node (it's `const false`), the `reducedMotion` snap path for `getBackgroundColor` is **not testable without a script.js refactor** that is out of scope for this pass.
+
+**Revised scope for Section 1:** 1 new test only — the `DAY_NIGHT_START` boundary (1a). The `reducedMotion` gap is noted as a known limitation; addressing it would require converting `reducedMotion` to a `let` or adding a seam, which is a separate refactor.
+
+Files touched: `tests/game.test.js` — expand `Day/Night Cycle` describe block.
+
+---
+
+## Section 2 — `audio.land()` and `audio.death()`
+
+**Existing coverage:** Both methods are called inside the "does not throw when ctx is unavailable" test and the "short-circuits in classic mode" test (which calls `jump`, `land`, and `death` together without isolating each). Neither has an individual test for its short-circuit path.
+
+**What to add:** 4 new tests mirroring the existing `audio.jump()` isolation tests.
+
+### 2a. `land()` short-circuits in classic mode
+
+`land()` delegates to `blip()`, which has `if (this.muted || !isUpdatedMode()) return` before calling `ensure()`. In classic mode `isUpdatedMode()` returns false, so `ensure()` is never reached.
+
+Test: spy on `audio.ensure`; call `audio.land()` in classic mode; assert `ensureCalls === 0`. Restore mode afterward.
+
+### 2b. `land()` short-circuits when muted
+
+Same spy pattern. Set `audio.setMuted(true)` before the call; assert `ensureCalls === 0`. Restore muted state afterward.
+
+### 2c. `death()` short-circuits in classic mode
+
+`death()` has its own `if (this.muted || !isUpdatedMode()) return` guard before calling `ensure()`. Same spy pattern in classic mode.
+
+### 2d. `death()` short-circuits when muted
+
+Same spy pattern with `audio.setMuted(true)`.
+
+Files touched: `tests/game.test.js` — expand `Audio` describe block.
+
+---
+
+## Section 3 — `announce()`
+
+**Current state:** `announce()` is not exported. `a11yLive` (the DOM reference it writes to) is not exported. No tests exist.
+
+**Fix:** Add two lines to the Node test-exposure block in `script.js`:
+
+```js
+global.announce  = announce;
+global.a11yLive  = a11yLive;
+```
+
+In Node, `a11yLive` is the stub object returned by `document.getElementById('a11y-live')` — a plain object with a writable `textContent` property. This makes both the function and its target observable from tests.
+
+**Tests (2 new):**
+
+- `announce('hello')` sets `a11yLive.textContent` to `'hello'`.
+- A second call `announce('world')` overwrites `a11yLive.textContent` to `'world'`.
+
+The null guard (`if (a11yLive && typeof a11yLive.textContent !== 'undefined')`) is already in the production code. In Node, `a11yLive` is always the stub (never null), so only the happy path is tested here. Testing the null guard would require a way to nullify `a11yLive` post-load, which is not worth the complexity.
+
+Files touched: `script.js` — Node exports block (2 lines). `tests/game.test.js` — new `announce()` describe block.
+
+---
+
+## Architecture summary
+
+| Section | Tests added | script.js change |
+|---|---|---|
+| `getBackgroundColor` boundary | 1 | none |
+| `audio.land()` short-circuits | 2 | none |
+| `audio.death()` short-circuits | 2 | none |
+| `announce()` | 2 | 2-line export addition |
+| **Total** | **7** | **2 lines** |
+
+All changes are in `tests/game.test.js` (7 new tests) and `script.js` (2 lines in the Node exports block). No logic changes. No HTML or CSS changes.
+
+---
+
+## Verification checklist
+
+- [ ] `getBackgroundColor(300)` returns `'#ffffff'` (boundary at DAY_NIGHT_START, `t = 0`).
+- [ ] `audio.land()` does not call `ensure()` in classic mode.
+- [ ] `audio.land()` does not call `ensure()` when muted.
+- [ ] `audio.death()` does not call `ensure()` in classic mode.
+- [ ] `audio.death()` does not call `ensure()` when muted.
+- [ ] `announce('hello')` sets `a11yLive.textContent` to `'hello'`.
+- [ ] `announce('world')` after `announce('hello')` overwrites `textContent` to `'world'`.
+- [ ] `npm test` passes — count is exactly 7 more than the baseline on the branch this PR targets.
+- [ ] No existing tests broken.

--- a/script.js
+++ b/script.js
@@ -1215,4 +1215,6 @@ if (typeof process !== 'undefined' && process.versions && process.versions.node)
   global.cfg = cfg;
   global.loadTuning = loadTuning;
   global.saveTuning = saveTuning;
+  global.announce  = announce;
+  global.a11yLive  = a11yLive;
 }

--- a/script.js
+++ b/script.js
@@ -1215,6 +1215,6 @@ if (typeof process !== 'undefined' && process.versions && process.versions.node)
   global.cfg = cfg;
   global.loadTuning = loadTuning;
   global.saveTuning = saveTuning;
-  global.announce  = announce;
-  global.a11yLive  = a11yLive;
+  global.announce = announce;
+  global.a11yLive = a11yLive;
 }

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -725,6 +725,11 @@ describe('Day/Night Cycle', () => {
       `Score 350 (t=0.5) should produce midpoint color #8d8d97`);
   });
 
+  it('returns #ffffff at DAY_NIGHT_START (score 300, t=0 boundary)', () => {
+    assertEquals(getBackgroundColor(300), '#ffffff',
+      'Score 300 is the first frame of the interpolation window — t=0 still produces white');
+  });
+
   it('should initialise stars once at score 400 and not re-init on second call', () => {
     resetGame();
     assert(!game.starsInitialised, 'starsInitialised should be false after reset');

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -500,6 +500,60 @@ describe('Audio (PR-B)', () => {
     assertEquals(ensureCalls, 0, 'Muted should short-circuit before ensure()');
     audio.setMuted(false);
   });
+
+  it('audio.land() does not call ensure() in classic mode', () => {
+    setMode(MODES.CLASSIC);
+    cancelAnimationFrame(game.animationFrameId);
+    audio.setMuted(false);
+    let ensureCalls = 0;
+    const originalEnsure = audio.ensure;
+    audio.ensure = function () { ensureCalls++; return null; };
+    audio.land();
+    audio.ensure = originalEnsure;
+    assertEquals(ensureCalls, 0, 'Classic mode: land() should not reach ensure()');
+    setMode(MODES.UPDATED);
+    cancelAnimationFrame(game.animationFrameId);
+  });
+
+  it('audio.land() does not call ensure() when muted', () => {
+    setMode(MODES.UPDATED);
+    cancelAnimationFrame(game.animationFrameId);
+    audio.setMuted(true);
+    let ensureCalls = 0;
+    const originalEnsure = audio.ensure;
+    audio.ensure = function () { ensureCalls++; return null; };
+    audio.land();
+    audio.ensure = originalEnsure;
+    assertEquals(ensureCalls, 0, 'Muted: land() should not reach ensure()');
+    audio.setMuted(false);
+  });
+
+  it('audio.death() does not call ensure() in classic mode', () => {
+    setMode(MODES.CLASSIC);
+    cancelAnimationFrame(game.animationFrameId);
+    audio.setMuted(false);
+    let ensureCalls = 0;
+    const originalEnsure = audio.ensure;
+    audio.ensure = function () { ensureCalls++; return null; };
+    audio.death();
+    audio.ensure = originalEnsure;
+    assertEquals(ensureCalls, 0, 'Classic mode: death() should not reach ensure()');
+    setMode(MODES.UPDATED);
+    cancelAnimationFrame(game.animationFrameId);
+  });
+
+  it('audio.death() does not call ensure() when muted', () => {
+    setMode(MODES.UPDATED);
+    cancelAnimationFrame(game.animationFrameId);
+    audio.setMuted(true);
+    let ensureCalls = 0;
+    const originalEnsure = audio.ensure;
+    audio.ensure = function () { ensureCalls++; return null; };
+    audio.death();
+    audio.ensure = originalEnsure;
+    assertEquals(ensureCalls, 0, 'Muted: death() should not reach ensure()');
+    audio.setMuted(false);
+  });
 });
 
 describe('Particles (PR-A)', () => {

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -1081,6 +1081,23 @@ describe('Live-tuning hook (PR-P3)', () => {
   });
 });
 
+describe('announce() accessibility helper', () => {
+  it('sets a11yLive.textContent to the announced message', () => {
+    a11yLive.textContent = '';
+    announce('hello');
+    assertEquals(a11yLive.textContent, 'hello',
+      'announce should write message to a11y live region');
+  });
+
+  it('overwrites textContent on repeated calls', () => {
+    a11yLive.textContent = '';
+    announce('first');
+    announce('second');
+    assertEquals(a11yLive.textContent, 'second',
+      'second announce should overwrite the first');
+  });
+});
+
 // --- Test Summary ---
 // Print summary both in the browser (on window.onload) and in Node (via a
 // setTimeout fallback so async tests have time to complete).


### PR DESCRIPTION
## Summary

- **`announce()` tests** — exported `announce` and `a11yLive` from the Node test environment (2-line addition to `script.js`); added 2 tests verifying the accessibility live region is written correctly
- **`getBackgroundColor` boundary** — 1 test pinning `getBackgroundColor(300) === '#ffffff'` (the t=0 boundary at `DAY_NIGHT_START` where the interpolation window begins)
- **`audio.land()` and `audio.death()` short-circuits** — 4 dedicated tests (mirroring the existing `audio.jump()` isolation tests) confirming both methods short-circuit before calling `ensure()` in classic mode and when muted

## Test plan

- [ ] `announce('hello')` sets `a11yLive.textContent` to `'hello'`
- [ ] Repeated `announce()` calls overwrite `textContent`
- [ ] `getBackgroundColor(300)` returns `'#ffffff'` (t=0 boundary)
- [ ] `audio.land()` does not call `ensure()` in classic mode
- [ ] `audio.land()` does not call `ensure()` when muted
- [ ] `audio.death()` does not call `ensure()` in classic mode
- [ ] `audio.death()` does not call `ensure()` when muted
- [ ] `npm test` passes — 85 tests (78 baseline + 7 new), 0 failures