### PR TITLE
feat(polish): remove width cap for tablets + pulse idle prompt

### DIFF
--- a/script.js
+++ b/script.js
@@ -757,7 +757,8 @@ function drawIdleScreen() {
   ctx.font = '22px ' + font;
   ctx.fillText('REX RUN', canvas.width / 2, canvas.height / 2 - 16);
 
-  ctx.fillStyle = 'rgba(255, 255, 255, 0.5)';
+  const pulseAlpha = 0.3 + 0.4 * (0.5 + 0.5 * Math.sin(game.animFrame * 0.08));
+  ctx.fillStyle = 'rgba(255, 255, 255, ' + pulseAlpha.toFixed(3) + ')';
   ctx.font = '13px ' + font;
   ctx.fillText('TAP / PRESS SPACE TO START', canvas.width / 2, canvas.height / 2 + 12);
 }

--- a/script.js
+++ b/script.js
@@ -342,7 +342,7 @@ function imageReady(img) {
 
 function initCanvasScale() {
   const dpr  = window.devicePixelRatio || 1;
-  const cssW = Math.min(window.innerWidth, GAME_CONFIG.CANVAS_W);
+  const cssW = window.innerWidth;
   const cssH = Math.round(cssW / 3);
   canvas.style.width  = cssW + 'px';
   canvas.style.height = cssH + 'px';

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -1852,6 +1852,30 @@ describe('Score count-up animation', () => {
   });
 });
 
+describe('Idle screen pulse animation', () => {
+  it('drawIdleScreen renders prompt with different fillStyle alpha at different animFrames', () => {
+    const origAnimFrame = game.animFrame;
+    const promptStyles  = [];
+
+    [0, 40].forEach(frame => {
+      game.animFrame = frame;
+      let capturedStyle;
+      const origFillText = ctx.fillText;
+      ctx.fillText = (text) => {
+        if (text === 'TAP / PRESS SPACE TO START') capturedStyle = ctx.fillStyle;
+      };
+      drawIdleScreen();
+      ctx.fillText = origFillText;
+      promptStyles.push(capturedStyle);
+    });
+
+    game.animFrame = origAnimFrame;
+
+    assert(promptStyles[0] !== promptStyles[1],
+      `Expected prompt fillStyle to differ between frame 0 and frame 40, got: ${JSON.stringify(promptStyles)}`);
+  });
+});
+
 describe('Tablet width cap removed', () => {
   it('initCanvasScale fills full innerWidth when wider than 600px', () => {
     const origInnerWidth = window.innerWidth;

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -1852,6 +1852,29 @@ describe('Score count-up animation', () => {
   });
 });
 
+describe('Tablet width cap removed', () => {
+  it('initCanvasScale fills full innerWidth when wider than 600px', () => {
+    const origInnerWidth = window.innerWidth;
+    const origDpr        = window.devicePixelRatio;
+    const origWidth      = canvas.width;
+    const origHeight     = canvas.height;
+
+    window.innerWidth       = 900;
+    window.devicePixelRatio = 1;
+    initCanvasScale();
+
+    const bitmapW = canvas.width;
+
+    window.innerWidth       = origInnerWidth;
+    window.devicePixelRatio = origDpr;
+    canvas.width            = origWidth;
+    canvas.height           = origHeight;
+
+    assertEquals(bitmapW, 900,
+      'canvas.width should be 900 when innerWidth=900 and dpr=1 (no 600px cap)');
+  });
+});
+
 if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
   window.addEventListener('load', () => setTimeout(printSummary, 500));
 } else {


### PR DESCRIPTION
Closes #33
Closes #31

## Summary

**Tablet width cap removed (#33)**
- Removed `Math.min(window.innerWidth, GAME_CONFIG.CANVAS_W)` clamp from `initCanvasScale()` — canvas now fills full viewport width on tablets and wide screens
- `ctx.scale` already handles the coordinate mapping, so no game logic changes needed

**Pulsing idle prompt (#31)**
- `drawIdleScreen` now drives `fillStyle` alpha via `0.3 + 0.4 * (0.5 + 0.5 * sin(animFrame * 0.08))` — a smooth 0.3→0.7 pulse on the "TAP / PRESS SPACE TO START" line
- Driven by `game.animFrame` which the IDLE game loop already increments each frame

## Test plan

- [ ] 130/130 tests passing
- [ ] On tablet/wide window — canvas fills full width
- [ ] On idle screen — prompt text gently pulses in opacity