### PR TITLE
feat(daily): Daily challenge mode — date-seeded runs, share button, daily best tracking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,10 +105,13 @@ Live-tuning overrides (`window.GAME_TUNING`) apply to **visuals only**. Physics,
 ## Modes & reduced-motion
 
 ```js
-const MODES = Object.freeze({ CLASSIC: 'classic', UPDATED: 'updated' });
-function isUpdatedMode() { return game.mode === MODES.UPDATED; }
+const MODES = Object.freeze({ CLASSIC: 'classic', UPDATED: 'updated', DAILY: 'daily' });
+function isDailyMode()   { return game.mode === MODES.DAILY; }
+function isUpdatedMode() { return game.mode === MODES.UPDATED || game.mode === MODES.DAILY; }
 const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 ```
+
+`MODES.DAILY` is activated by the `#daily-btn` button (not persisted to `dino-mode`). `isUpdatedMode()` returns `true` for both UPDATED and DAILY, so all juice/variety features apply in daily runs.
 
 `reducedMotion` is read once at module load. Each ambient feature self-gates internally:
 
@@ -127,6 +130,8 @@ const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matc
 | `dino-muted` | `'0'` / `'1'` | `audio.setMuted` | `audio.muted` init |
 | `dino-high-score` | integer string | death handler | `game.highScore` init |
 | `dino-tuning` | JSON | `saveTuning()` | `loadTuning()` at boot |
+| `dino-daily-date` | YYYYMMDD integer string | `saveDailyBest()` | `loadDailyBest()` at reset |
+| `dino-daily-best` | integer string | `saveDailyBest()` | `game.dailyBest` init |
 
 ## Test harness
 

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
 <body>
   <div id="game-wrapper" role="application" aria-label="Chrome dino game">
     <button id="mute-btn" type="button" aria-pressed="false" aria-label="Mute sound">&#x1F50A;</button>
+    <button id="daily-btn" type="button" aria-pressed="false" aria-label="Daily challenge">&#x1F4C5;</button>
     <div id="mode-toggle" role="group" aria-label="Game mode">
       <button type="button" data-mode="classic" aria-pressed="false">Classic</button>
       <button type="button" data-mode="updated" aria-pressed="true">Updated</button>

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
     </div>
     <canvas id="gameCanvas" width="600" height="200" aria-label="Dino running game. Press space to jump."></canvas>
     <button id="jump-btn" aria-label="Jump">TAP TO JUMP</button>
+    <button id="share-btn" aria-label="Copy daily result to clipboard" style="display:none">&#x1F4CB; Copy result</button>
     <div id="a11y-live" class="sr-only" aria-live="polite" aria-atomic="true"></div>
   </div>
   <script src="script.js?v=__VERSION__"></script>

--- a/script.js
+++ b/script.js
@@ -467,7 +467,7 @@ const DifficultyProfile = {
   },
 };
 
-const MODES = Object.freeze({ CLASSIC: 'classic', UPDATED: 'updated' });
+const MODES = Object.freeze({ CLASSIC: 'classic', UPDATED: 'updated', DAILY: 'daily' });
 
 // Read the saved mode (defaults to 'updated' for first-time players). Persists
 // across reload so the user's preference is remembered.
@@ -919,7 +919,8 @@ for (let i = 0; i < PARTICLE_POOL_SIZE; i++) {
   particles.push({ x: 0, y: 0, vx: 0, vy: 0, life: 0, maxLife: 1, size: 0, color: '', gravity: 0 });
 }
 
-function isUpdatedMode() { return game.mode === MODES.UPDATED; }
+function isDailyMode()   { return game.mode === MODES.DAILY; }
+function isUpdatedMode() { return game.mode === MODES.UPDATED || game.mode === MODES.DAILY; }
 
 function emitParticles(kind, x, y) {
   if (!isUpdatedMode()) return 0;
@@ -1191,7 +1192,9 @@ function resetGame() {
   game.newBestShown      = false;
   game.isNewBest         = false;
   game.previousHighScore = 0;
-  game.rng = mulberry32(Date.now() & 0xffffffff);
+  game.rng = mulberry32(isDailyMode() ? dailySeed() : (Date.now() & 0xffffffff));
+  game.dailyBest = loadDailyBest();
+  game.copyFlashFrames = 0;
   game.nextSpawnGap = computeNextSpawnGap(game.rng, DifficultyProfile.speedAtScore(game.score), game.mode);
   initClouds();
   initHills();
@@ -1444,4 +1447,5 @@ if (typeof process !== 'undefined' && process.versions && process.versions.node)
   global.dailyNumber = dailyNumber;
   global.loadDailyBest = loadDailyBest;
   global.saveDailyBest = saveDailyBest;
+  global.isDailyMode = isDailyMode;
 }

--- a/script.js
+++ b/script.js
@@ -763,7 +763,19 @@ function drawScore() {
     GAME_CONFIG.CANVAS_W - GAME_CONFIG.SCORE_X_OFFSET,
     GAME_CONFIG.SCORE_Y
   );
-  if (game.highScore > 0) {
+  if (isDailyMode()) {
+    // TODAY label replaces HI in daily challenge mode
+    const todayBest = game.dailyBest > 0 ? String(game.dailyBest).padStart(5, '0') : '-----';
+    ctx.fillText(
+      'TODAY ' + todayBest,
+      GAME_CONFIG.CANVAS_W - GAME_CONFIG.SCORE_X_OFFSET - GAME_CONFIG.SCORE_HI_X_OFFSET - 20,
+      GAME_CONFIG.SCORE_Y
+    );
+    // Daily badge top-left
+    ctx.font = '13px ' + cfg('SCORE_FONT_FAMILY');
+    ctx.textAlign = 'left';
+    ctx.fillText('📅 DAILY #' + dailyNumber(), 12, GAME_CONFIG.SCORE_Y);
+  } else if (game.highScore > 0) {
     ctx.fillText(
       'HI ' + String(game.highScore).padStart(5, '0'),
       GAME_CONFIG.CANVAS_W - GAME_CONFIG.SCORE_X_OFFSET - GAME_CONFIG.SCORE_HI_X_OFFSET,

--- a/script.js
+++ b/script.js
@@ -1150,6 +1150,47 @@ if (muteBtn && muteBtn.addEventListener) {
   refreshMuteButton();
 }
 
+// Daily challenge button — activates MODES.DAILY (locks Updated behaviour)
+// and hides the Classic/Updated toggle via the .daily-active class.
+const dailyBtn = document.getElementById('daily-btn');
+const gameWrapper = document.getElementById('game-wrapper');
+
+function refreshDailyButton() {
+  if (!dailyBtn || !dailyBtn.setAttribute) return;
+  const active = isDailyMode();
+  dailyBtn.setAttribute('aria-pressed', String(active));
+  dailyBtn.setAttribute('aria-label', active ? 'Leave daily challenge' : 'Daily challenge');
+  if (gameWrapper && gameWrapper.classList) {
+    if (active) gameWrapper.classList.add('daily-active');
+    else gameWrapper.classList.remove('daily-active');
+  }
+}
+
+if (dailyBtn && dailyBtn.addEventListener) {
+  const onDailyTap = (event) => {
+    if (event) event.stopPropagation();
+    const entering = !isDailyMode();
+    if (entering) {
+      game.mode = MODES.DAILY;
+    } else {
+      game.mode = MODES.UPDATED;
+      localStorage.setItem('dino-mode', MODES.UPDATED);
+    }
+    refreshDailyButton();
+    cancelAnimationFrame(game.animationFrameId);
+    resetGame();
+    gameLoop();
+    announce(entering ? `Daily challenge #${dailyNumber()}` : 'Updated mode');
+  };
+  dailyBtn.addEventListener('click', onDailyTap);
+  dailyBtn.addEventListener('touchstart', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    onDailyTap(event);
+  }, { passive: false });
+  refreshDailyButton();
+}
+
 // Resume the AudioContext when the tab becomes visible again. Browsers
 // suspend the ctx when the page is hidden; without this, audio dies silently
 // on tab-switch even though no error is thrown.

--- a/script.js
+++ b/script.js
@@ -476,6 +476,30 @@ function loadMode() {
   return stored === MODES.CLASSIC ? MODES.CLASSIC : MODES.UPDATED;
 }
 
+// --- Daily challenge helpers -------------------------------------------
+// Epoch: project launch 2026-03-01 UTC. Day 1 = that date.
+const DAILY_EPOCH_MS = new Date('2026-03-01T00:00:00Z').getTime();
+
+// Returns today's date as a YYYYMMDD integer — same value for every player
+// on the same calendar day, used as the mulberry32 seed for daily runs.
+function dailySeed() {
+  const d = new Date();
+  return d.getFullYear() * 10000 + (d.getMonth() + 1) * 100 + d.getDate();
+}
+
+// Ordinal day number shown in the HUD badge and share text (#1, #2, …).
+function dailyNumber() {
+  return Math.floor((Date.now() - DAILY_EPOCH_MS) / 86400000) + 1;
+}
+
+// Returns the player's best score for today's daily run, or 0 if they
+// haven't played today or the stored date is stale.
+function loadDailyBest() {
+  const storedDate = parseInt(localStorage.getItem('dino-daily-date') || '0', 10);
+  if (storedDate !== dailySeed()) return 0;
+  return parseInt(localStorage.getItem('dino-daily-best') || '0', 10);
+}
+
 // All mutable game state lives on this object. Keeping it in one place prevents
 // stray top-level globals and makes resets + test inspection simpler.
 const game = {
@@ -506,6 +530,8 @@ const game = {
   previousHighScore: 0,
   rng:              mulberry32(Date.now() & 0xffffffff),
   mode:             loadMode(),
+  dailyBest:        loadDailyBest(),
+  copyFlashFrames:  0,
 };
 
 function setMode(newMode) {
@@ -516,6 +542,17 @@ function setMode(newMode) {
   cancelAnimationFrame(game.animationFrameId);
   resetGame();
   gameLoop();
+}
+
+// Persist the player's daily best if score beats the current stored value.
+// Also ticks game.dailyBest up in memory so the death screen can read it.
+function saveDailyBest(score) {
+  const current = loadDailyBest();
+  if (score > current) {
+    localStorage.setItem('dino-daily-date', String(dailySeed()));
+    localStorage.setItem('dino-daily-best', String(score));
+    game.dailyBest = score;
+  }
 }
 
 // == SECTION 5: RENDERING ==
@@ -1403,4 +1440,8 @@ if (typeof process !== 'undefined' && process.versions && process.versions.node)
   global.DifficultyProfile = DifficultyProfile;
   global.announce = announce;
   global.a11yLive = a11yLive;
+  global.dailySeed = dailySeed;
+  global.dailyNumber = dailyNumber;
+  global.loadDailyBest = loadDailyBest;
+  global.saveDailyBest = saveDailyBest;
 }

--- a/script.js
+++ b/script.js
@@ -544,6 +544,21 @@ function setMode(newMode) {
   gameLoop();
 }
 
+// Build and copy the daily result string to the clipboard.
+// Returns the text so tests can assert its shape without touching clipboard.
+function shareDailyResult() {
+  const score = game.dailyBest > 0 ? game.dailyBest : Math.floor(game.score);
+  const text = [
+    'Rex Daily #' + dailyNumber() + ' 🦕',
+    'Score: ' + score,
+    'https://snehiths19.github.io/chrome-offline-Rex/',
+  ].join('\n');
+  if (typeof navigator !== 'undefined' && navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(text).catch(() => {});
+  }
+  return text;
+}
+
 // Persist the player's daily best if score beats the current stored value.
 // Also ticks game.dailyBest up in memory so the death screen can read it.
 function saveDailyBest(score) {
@@ -832,56 +847,99 @@ function drawGameOverScreen() {
   const font = cfg('SCORE_FONT_FAMILY');
   const t = Math.min(game.deathAnimFrame / GAME_CONFIG.DEATH_ANIM_FRAMES, 1);
   const displayScore = Math.round(t * Math.floor(game.score));
+
   ctx.fillStyle = 'rgba(0, 0, 0, 0.75)';
   ctx.fillRect(0, 0, GAME_CONFIG.CANVAS_W, GAME_CONFIG.CANVAS_H);
   ctx.textAlign = 'center';
 
-  if (game.isNewBest) {
-    // New record — celebration takeover
+  if (isDailyMode()) {
+    // Daily challenge death screen — THIS RUN vs TODAY BEST, no all-time comparison
+    const todayBest = game.dailyBest;
+    const delta = todayBest > 0 ? todayBest - displayScore : 0;
+
+    ctx.fillStyle = 'rgba(255, 140, 0, 0.9)';
+    ctx.font = '13px ' + font;
+    ctx.fillText('📅 DAILY #' + dailyNumber(), GAME_CONFIG.CANVAS_W / 2, GAME_CONFIG.CANVAS_H / 2 - 48);
+
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.5)';
+    ctx.font = '12px ' + font;
+    ctx.fillText('THIS RUN', GAME_CONFIG.CANVAS_W * 0.2, GAME_CONFIG.CANVAS_H / 2 - 14);
     ctx.fillStyle = 'white';
-    ctx.font = '15px ' + font;
-    ctx.fillText('★  NEW BEST  ★', GAME_CONFIG.CANVAS_W / 2, GAME_CONFIG.CANVAS_H / 2 - 36);
+    ctx.font = '28px ' + font;
+    ctx.fillText(String(displayScore).padStart(5, '0'), GAME_CONFIG.CANVAS_W * 0.2, GAME_CONFIG.CANVAS_H / 2 + 14);
 
-    ctx.font = '42px ' + font;
-    ctx.fillText(String(displayScore).padStart(5, '0'), GAME_CONFIG.CANVAS_W / 2, GAME_CONFIG.CANVAS_H / 2 - 4);
-
-    if (game.previousHighScore > 0) {
+    if (todayBest > 0) {
       ctx.fillStyle = 'rgba(255, 255, 255, 0.5)';
-      ctx.font = '13px ' + font;
-      const improvement = displayScore - game.previousHighScore;
-      ctx.fillText('+' + improvement + ' over your previous best', GAME_CONFIG.CANVAS_W / 2, GAME_CONFIG.CANVAS_H / 2 + 28);
+      ctx.font = '16px ' + font;
+      ctx.fillText(delta > 0 ? '← +' + delta + ' →' : '← best →', GAME_CONFIG.CANVAS_W / 2, GAME_CONFIG.CANVAS_H / 2 - 10);
+      ctx.fillStyle = 'rgba(255, 255, 255, 0.35)';
+      ctx.font = '11px ' + font;
+      ctx.fillText('today best', GAME_CONFIG.CANVAS_W / 2, GAME_CONFIG.CANVAS_H / 2 + 10);
+
+      ctx.fillStyle = 'rgba(255, 255, 255, 0.5)';
+      ctx.font = '12px ' + font;
+      ctx.fillText('TODAY BEST', GAME_CONFIG.CANVAS_W * 0.8, GAME_CONFIG.CANVAS_H / 2 - 14);
+      ctx.fillStyle = 'white';
+      ctx.font = '28px ' + font;
+      ctx.fillText(String(todayBest).padStart(5, '0'), GAME_CONFIG.CANVAS_W * 0.8, GAME_CONFIG.CANVAS_H / 2 + 14);
+    }
+
+    // Show or hide the DOM share button based on animation completion
+    const shareBtnEl = document.getElementById('share-btn');
+    if (shareBtnEl && shareBtnEl.style) {
+      shareBtnEl.style.display = t >= 1 ? 'block' : 'none';
+      if (t >= 1) {
+        shareBtnEl.textContent = game.copyFlashFrames > 0 ? '✓ Copied!' : '📋 Copy result';
+      }
     }
   } else {
-    // Normal death — side-by-side comparison
-    const delta    = game.highScore - Math.floor(game.score);
-    const scoreStr = String(displayScore).padStart(5, '0');
-    const bestStr  = String(game.highScore).padStart(5, '0');
+    if (game.isNewBest) {
+      // New record — celebration takeover
+      ctx.fillStyle = 'white';
+      ctx.font = '15px ' + font;
+      ctx.fillText('★  NEW BEST  ★', GAME_CONFIG.CANVAS_W / 2, GAME_CONFIG.CANVAS_H / 2 - 36);
 
-    ctx.fillStyle = 'rgba(255, 255, 255, 0.5)';
-    ctx.font = '12px ' + font;
-    ctx.fillText('THIS RUN',  GAME_CONFIG.CANVAS_W * 0.2, GAME_CONFIG.CANVAS_H / 2 - 14);
-    ctx.fillStyle = 'white';
-    ctx.font = '28px ' + font;
-    ctx.fillText(scoreStr,   GAME_CONFIG.CANVAS_W * 0.2, GAME_CONFIG.CANVAS_H / 2 + 14);
+      ctx.font = '42px ' + font;
+      ctx.fillText(String(displayScore).padStart(5, '0'), GAME_CONFIG.CANVAS_W / 2, GAME_CONFIG.CANVAS_H / 2 - 4);
 
-    ctx.fillStyle = 'rgba(255, 255, 255, 0.5)';
-    ctx.font = '16px ' + font;
-    ctx.fillText('← ' + delta + ' →', GAME_CONFIG.CANVAS_W / 2, GAME_CONFIG.CANVAS_H / 2 - 10);
+      if (game.previousHighScore > 0) {
+        ctx.fillStyle = 'rgba(255, 255, 255, 0.5)';
+        ctx.font = '13px ' + font;
+        const improvement = displayScore - game.previousHighScore;
+        ctx.fillText('+' + improvement + ' over your previous best', GAME_CONFIG.CANVAS_W / 2, GAME_CONFIG.CANVAS_H / 2 + 28);
+      }
+    } else {
+      // Normal death — side-by-side comparison
+      const delta    = game.highScore - Math.floor(game.score);
+      const scoreStr = String(displayScore).padStart(5, '0');
+      const bestStr  = String(game.highScore).padStart(5, '0');
+
+      ctx.fillStyle = 'rgba(255, 255, 255, 0.5)';
+      ctx.font = '12px ' + font;
+      ctx.fillText('THIS RUN',  GAME_CONFIG.CANVAS_W * 0.2, GAME_CONFIG.CANVAS_H / 2 - 14);
+      ctx.fillStyle = 'white';
+      ctx.font = '28px ' + font;
+      ctx.fillText(scoreStr,   GAME_CONFIG.CANVAS_W * 0.2, GAME_CONFIG.CANVAS_H / 2 + 14);
+
+      ctx.fillStyle = 'rgba(255, 255, 255, 0.5)';
+      ctx.font = '16px ' + font;
+      ctx.fillText('← ' + delta + ' →', GAME_CONFIG.CANVAS_W / 2, GAME_CONFIG.CANVAS_H / 2 - 10);
+      ctx.fillStyle = 'rgba(255, 255, 255, 0.35)';
+      ctx.font = '11px ' + font;
+      ctx.fillText('from best', GAME_CONFIG.CANVAS_W / 2, GAME_CONFIG.CANVAS_H / 2 + 10);
+
+      ctx.fillStyle = 'rgba(255, 255, 255, 0.5)';
+      ctx.font = '12px ' + font;
+      ctx.fillText('YOUR BEST', GAME_CONFIG.CANVAS_W * 0.8, GAME_CONFIG.CANVAS_H / 2 - 14);
+      ctx.fillStyle = 'white';
+      ctx.font = '28px ' + font;
+      ctx.fillText(bestStr,    GAME_CONFIG.CANVAS_W * 0.8, GAME_CONFIG.CANVAS_H / 2 + 14);
+    }
+
     ctx.fillStyle = 'rgba(255, 255, 255, 0.35)';
-    ctx.font = '11px ' + font;
-    ctx.fillText('from best', GAME_CONFIG.CANVAS_W / 2, GAME_CONFIG.CANVAS_H / 2 + 10);
-
-    ctx.fillStyle = 'rgba(255, 255, 255, 0.5)';
-    ctx.font = '12px ' + font;
-    ctx.fillText('YOUR BEST', GAME_CONFIG.CANVAS_W * 0.8, GAME_CONFIG.CANVAS_H / 2 - 14);
-    ctx.fillStyle = 'white';
-    ctx.font = '28px ' + font;
-    ctx.fillText(bestStr,    GAME_CONFIG.CANVAS_W * 0.8, GAME_CONFIG.CANVAS_H / 2 + 14);
+    ctx.font = '13px ' + font;
+    ctx.fillText('Tap / Press Space to Restart', GAME_CONFIG.CANVAS_W / 2, GAME_CONFIG.CANVAS_H - 16);
   }
-
-  ctx.fillStyle = 'rgba(255, 255, 255, 0.35)';
-  ctx.font = '13px ' + font;
-  ctx.fillText('Tap / Press Space to Restart', GAME_CONFIG.CANVAS_W / 2, GAME_CONFIG.CANVAS_H - 16);
 }
 
 function drawMilestoneFlash() {
@@ -1162,6 +1220,22 @@ if (muteBtn && muteBtn.addEventListener) {
   refreshMuteButton();
 }
 
+// Share button — shown on death screen during daily challenge only.
+const shareBtn = document.getElementById('share-btn');
+if (shareBtn && shareBtn.addEventListener) {
+  const onShareTap = (event) => {
+    if (event) event.stopPropagation();
+    shareDailyResult();
+    game.copyFlashFrames = 90; // ~1.5 s at 60 fps
+  };
+  shareBtn.addEventListener('click', onShareTap);
+  shareBtn.addEventListener('touchstart', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    onShareTap(event);
+  }, { passive: false });
+}
+
 // Daily challenge button — activates MODES.DAILY (locks Updated behaviour)
 // and hides the Classic/Updated toggle via the .daily-active class.
 const dailyBtn = document.getElementById('daily-btn');
@@ -1248,6 +1322,8 @@ function resetGame() {
   game.rng = mulberry32(isDailyMode() ? dailySeed() : (Date.now() & 0xffffffff));
   game.dailyBest = loadDailyBest();
   game.copyFlashFrames = 0;
+  const shareBtnEl = document.getElementById('share-btn');
+  if (shareBtnEl && shareBtnEl.style) shareBtnEl.style.display = 'none';
   game.nextSpawnGap = computeNextSpawnGap(game.rng, DifficultyProfile.speedAtScore(game.score), game.mode);
   initClouds();
   initHills();
@@ -1281,6 +1357,7 @@ function gameLoop() {
       drawGameOverScreen();
       game.animationFrameId = requestAnimationFrame(gameLoop);
     } else {
+      if (game.copyFlashFrames > 0) game.copyFlashFrames--;
       drawGameOverScreen();
     }
     return;
@@ -1396,6 +1473,7 @@ function gameLoop() {
         game.highScore = finalScore;
         localStorage.setItem('dino-high-score', game.highScore);
       }
+      if (isDailyMode()) saveDailyBest(finalScore);
       announce('Game over. Score ' + finalScore + '. High score ' + game.highScore + '. Press space to restart.');
       game.animationFrameId = requestAnimationFrame(gameLoop);
       return;
@@ -1501,4 +1579,5 @@ if (typeof process !== 'undefined' && process.versions && process.versions.node)
   global.loadDailyBest = loadDailyBest;
   global.saveDailyBest = saveDailyBest;
   global.isDailyMode = isDailyMode;
+  global.shareDailyResult = shareDailyResult;
 }

--- a/style.css
+++ b/style.css
@@ -158,6 +158,24 @@ body {
   #jump-btn { display: block; }
 }
 
+#share-btn {
+  margin-top: 10px;
+  padding: 10px 28px;
+  font-size: 15px;
+  font-weight: bold;
+  background: rgba(255, 140, 0, 0.9);
+  color: white;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  transition: background-color 80ms ease-out, transform 80ms ease-out;
+}
+
+#share-btn:active { transform: scale(0.96); }
+#share-btn:focus-visible { outline: 2px solid #4a90e2; outline-offset: 2px; }
+
 /* Visually hidden but readable by screen readers */
 .sr-only {
   position: absolute;

--- a/style.css
+++ b/style.css
@@ -47,6 +47,35 @@ body {
 #mute-btn:active { transform: scale(0.95); }
 #mute-btn:focus-visible { outline: 2px solid #4a90e2; outline-offset: 2px; }
 
+#daily-btn {
+  position: absolute;
+  top: 6px;
+  left: 68px;
+  z-index: 2;
+  padding: 4px 8px;
+  font-size: 14px;
+  line-height: 1;
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid #999;
+  border-radius: 999px;
+  cursor: pointer;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  transition: background-color 80ms ease-out, transform 80ms ease-out;
+}
+
+#daily-btn[aria-pressed='true'] {
+  background: rgba(255, 140, 0, 0.9);
+  color: #fff;
+  border-color: #cc6600;
+}
+
+#daily-btn:hover { transform: scale(1.05); }
+#daily-btn:active { transform: scale(0.95); }
+#daily-btn:focus-visible { outline: 2px solid #4a90e2; outline-offset: 2px; }
+
+.daily-active #mode-toggle { display: none; }
+
 #mode-toggle {
   position: absolute;
   top: 6px;

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -1899,6 +1899,35 @@ describe('Tablet width cap removed', () => {
   });
 });
 
+describe('Daily mode RNG seeding', () => {
+  it('resetGame() in daily mode seeds rng from dailySeed(), not Date.now()', () => {
+    const origMode = game.mode;
+    game.mode = MODES.DAILY;
+    resetGame();
+    // Pull first two values from the seeded RNG
+    const v1a = game.rng();
+    game.mode = MODES.DAILY;
+    resetGame();
+    const v1b = game.rng();
+    assertEquals(v1a, v1b, 'First RNG value should be identical across two daily resets');
+    game.mode = origMode;
+    resetGame();
+  });
+
+  it('two resets in daily mode produce the same obstacle type sequence', () => {
+    const origMode = game.mode;
+    game.mode = MODES.DAILY;
+    resetGame();
+    const type1 = pickObstacleType(game.rng, 300, MODES.DAILY);
+    game.mode = MODES.DAILY;
+    resetGame();
+    const type2 = pickObstacleType(game.rng, 300, MODES.DAILY);
+    assertEquals(type1.id, type2.id, 'Same seed should produce same obstacle type');
+    game.mode = origMode;
+    resetGame();
+  });
+});
+
 describe('Daily seed', () => {
   it('dailySeed() returns an 8-digit YYYYMMDD integer', () => {
     const seed = dailySeed();

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -1899,6 +1899,27 @@ describe('Tablet width cap removed', () => {
   });
 });
 
+describe('Share result', () => {
+  it('shareDailyResult() returns a string containing the daily number and score', () => {
+    const origDailyBest = game.dailyBest;
+    game.dailyBest = 500;
+    const text = shareDailyResult();
+    assert(typeof text === 'string', 'shareDailyResult() should return a string');
+    assert(text.includes('#' + dailyNumber()), 'Result should contain the daily number');
+    assert(text.includes('500'), 'Result should contain the daily best score');
+    game.dailyBest = origDailyBest;
+  });
+
+  it('shareDailyResult() does not throw when navigator is unavailable', () => {
+    const origDailyBest = game.dailyBest;
+    game.dailyBest = 0;
+    let threw = false;
+    try { shareDailyResult(); } catch (e) { threw = true; }
+    assert(!threw, 'shareDailyResult() should not throw even with no clipboard');
+    game.dailyBest = origDailyBest;
+  });
+});
+
 describe('Daily mode RNG seeding', () => {
   it('resetGame() in daily mode seeds rng from dailySeed(), not Date.now()', () => {
     const origMode = game.mode;

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -1899,6 +1899,70 @@ describe('Tablet width cap removed', () => {
   });
 });
 
+describe('Daily seed', () => {
+  it('dailySeed() returns an 8-digit YYYYMMDD integer', () => {
+    const seed = dailySeed();
+    assert(Number.isInteger(seed), `Expected integer, got ${seed}`);
+    assert(seed >= 20000101 && seed <= 29991231, `Expected YYYYMMDD range, got ${seed}`);
+  });
+
+  it('dailySeed() returns the same value on consecutive calls', () => {
+    assertEquals(dailySeed(), dailySeed(), 'dailySeed() should be stable within a tick');
+  });
+});
+
+describe('Daily number', () => {
+  it('dailyNumber() returns a positive integer', () => {
+    const n = dailyNumber();
+    assert(Number.isInteger(n) && n > 0, `Expected positive integer, got ${n}`);
+  });
+
+  it('dailyNumber() is >= 62 (project is past day 62 after 2026-05-01)', () => {
+    assert(dailyNumber() >= 62, `Expected >= 62, got ${dailyNumber()}`);
+  });
+});
+
+describe('Daily best persistence', () => {
+  it('loadDailyBest() returns 0 when stored date does not match today', () => {
+    const origDate = localStorage.getItem('dino-daily-date');
+    const origBest = localStorage.getItem('dino-daily-best');
+    localStorage.setItem('dino-daily-date', '19990101');
+    localStorage.setItem('dino-daily-best', '999');
+    assertEquals(loadDailyBest(), 0, 'Should return 0 on stale date');
+    origDate !== null ? localStorage.setItem('dino-daily-date', origDate) : localStorage.removeItem('dino-daily-date');
+    origBest !== null ? localStorage.setItem('dino-daily-best', origBest) : localStorage.removeItem('dino-daily-best');
+  });
+
+  it('loadDailyBest() returns stored value when date matches today', () => {
+    const origDate = localStorage.getItem('dino-daily-date');
+    const origBest = localStorage.getItem('dino-daily-best');
+    localStorage.setItem('dino-daily-date', String(dailySeed()));
+    localStorage.setItem('dino-daily-best', '847');
+    assertEquals(loadDailyBest(), 847, 'Should return 847 when date matches');
+    origDate !== null ? localStorage.setItem('dino-daily-date', origDate) : localStorage.removeItem('dino-daily-date');
+    origBest !== null ? localStorage.setItem('dino-daily-best', origBest) : localStorage.removeItem('dino-daily-best');
+  });
+
+  it('saveDailyBest() stores score and updates game.dailyBest; lower score does not overwrite', () => {
+    const origDate = localStorage.getItem('dino-daily-date');
+    const origBest = localStorage.getItem('dino-daily-best');
+    const origGameBest = game.dailyBest;
+    localStorage.removeItem('dino-daily-date');
+    localStorage.removeItem('dino-daily-best');
+
+    saveDailyBest(500);
+    assertEquals(loadDailyBest(), 500, 'loadDailyBest() should return 500 after save');
+    assertEquals(game.dailyBest, 500, 'game.dailyBest should be 500');
+
+    saveDailyBest(200);
+    assertEquals(loadDailyBest(), 500, 'Lower score must not overwrite stored best');
+
+    origDate !== null ? localStorage.setItem('dino-daily-date', origDate) : localStorage.removeItem('dino-daily-date');
+    origBest !== null ? localStorage.setItem('dino-daily-best', origBest) : localStorage.removeItem('dino-daily-best');
+    game.dailyBest = origGameBest;
+  });
+});
+
 if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
   window.addEventListener('load', () => setTimeout(printSummary, 500));
 } else {


### PR DESCRIPTION
## Summary

- Adds a **Daily Challenge** mode seeded from the current calendar date (`YYYYMMDD`), giving every player the same obstacle sequence each day
- Activated by a new `📅` button (separate from the Classic/Updated toggle, which hides while daily is active)
- Tracks and persists **daily best** independently from all-time best via two new `localStorage` keys (`dino-daily-date`, `dino-daily-best`)
- Death screen in daily mode shows **THIS RUN vs TODAY BEST** layout with a **📋 Copy result** share button (clipboard API, ✓ Copied flash feedback)
- HUD shows `📅 DAILY #N` badge top-left and `TODAY XXXXX` label replacing `HI` while in daily mode
- `isUpdatedMode()` returns `true` for `MODES.DAILY`, so all juice/variety features (particles, audio, obstacle types, hills) activate automatically

## What changed

| File | Changes |
|---|---|
| `script.js` | `MODES.DAILY`, `isDailyMode()`, `isUpdatedMode()` updated, `dailySeed()`, `dailyNumber()`, `loadDailyBest()`, `saveDailyBest()`, `shareDailyResult()`, `refreshDailyButton()`, death handler, `drawGameOverScreen()`, `drawScore()`, `resetGame()`, Section 10 exposure |
| `index.html` | `#daily-btn`, `#share-btn` |
| `style.css` | `#daily-btn`, `#share-btn`, `.daily-active #mode-toggle { display: none }` |
| `CLAUDE.md` | localStorage key table + MODES section updated |
| `CONTEXT.md` | Daily Challenge domain terms added |
| `docs/adr/0001` | Why daily is a separate button, not a third mode |
| `docs/adr/0002` | Why unlimited attempts instead of one-and-done |

## Test plan

- [ ] CI passes (`node tests/game.test.js` — 9 new tests across Daily seed, Daily number, Daily best persistence, Share result, Daily mode RNG seeding)
- [ ] Opening two tabs on the same day produces the same obstacle sequence
- [ ] Daily best persists across page reloads on the same day
- [ ] Daily best resets to 0 on a new day
- [ ] `📅` button activates daily mode; Classic/Updated toggle disappears
- [ ] `📅` button again deactivates daily mode; toggle reappears
- [ ] HUD shows `📅 DAILY #N` badge and `TODAY` label while in daily mode
- [ ] Death screen shows THIS RUN vs TODAY BEST layout (not all-time best)
- [ ] Share button appears after count-up animation; shows `✓ Copied!` for ~1.5 s
- [ ] With OS reduce-motion on: particles suppressed, audio unchanged, HUD badge visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)