### PR TITLE
refactor(difficulty): deepen DifficultyProfile.nextObstacle()

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ The file is divided into numbered sections. Add new code inside the section it b
 4. **Section 4 — Game state** (~line 380). `STATE` enum, `MODES`, the `game` object, the `mulberry32` seeded RNG, `audio` object.
 5. **Section 5 — Rendering** (~line 470). Pure draw functions: `drawBackground`, `drawDino`, `drawObstacles`, `drawClouds`, `drawHills`, `drawSkyTint`, `drawDeathFlash`, `drawScore`, `drawMilestoneFlash`, `drawNewBestBadge`, etc.
 6. **Feature registry** (~line 770). `FEATURES` array + `runFeatureUpdates` + `runFeatureDraws(layer)`. Declarative ordering for ambient features (hills, clouds, particles, skyTint).
-7. **Section 6 — Physics & game logic** (~line 800). `spawnObstacle`, `pickObstacleType`, `computeNextSpawnGap`, collision, `jump`, `resetGame`.
+7. **Section 6 — Physics & game logic** (~line 800). `DifficultyProfile.nextObstacle()` (type + gap), `spawnObstacle`, collision, `jump`, `resetGame`. `pickObstacleType` and `computeNextSpawnGap` are internal helpers — not exported.
 8. **Section 7 — Input handlers** (~line 870). Keyboard + mouse + touch. Mute and mode-toggle buttons live here too.
 9. **Section 8 — Game loop** (~line 970). Three branches: WAITING, RUNNING, DEAD. RUNNING uses the feature registry; WAITING and DEAD are hand-written.
 10. **Section 9 — Initialisation** (~line 1160). Loads assets, sets state, kicks off the loop.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -9,3 +9,28 @@
 **Plateau** — the ceiling of the difficulty curve. Chosen to feel "focusable but demanding" — a skilled player can hold this speed indefinitely, but it is not forgiving of lapses in attention.
 
 **Level** — a discrete score milestone (every 100 points) used for milestone flash effects and visual feedback only. Speed no longer steps at level boundaries; it increases continuously.
+
+## Daily Challenge
+
+**Daily Challenge** — a play mode in which the obstacle sequence is seeded from the current calendar date, giving every player the same run each day. Activated by a dedicated button; always runs in Updated mode.
+_Avoid_: daily mode, date mode, challenge mode
+
+**Daily seed** — an integer derived from the current date in YYYYMMDD format (e.g. `20260501`) used as the RNG seed for a daily challenge run. Recomputed each day; the same seed produces the same obstacle sequence for all players.
+_Avoid_: date seed, daily RNG
+
+**Daily number** — the count of days since the project epoch (2026-03-01), shown as `#N` in the HUD badge and share text. Day 1 = 2026-03-01.
+_Avoid_: day number, challenge number
+
+**Daily best** — the player's highest score on today's daily challenge run, stored separately from all-time best. Resets automatically when the calendar date changes.
+_Avoid_: daily high score, today's score, daily record
+
+**Share result** — a clipboard-copied text summarising the player's daily best, available from the Game Over screen during a daily challenge run. Format: `Rex Daily #N 🦕 / Score: X / <url>`.
+_Avoid_: share score, copy result, clipboard share
+
+## Relationships
+
+- A **Daily Challenge** run uses one **Daily seed** derived from the current date
+- The **Daily seed** is the sole input to `game.rng` for a daily challenge run, replacing the `Date.now()` seed used in free play
+- The **Daily number** is computed from the same date as the **Daily seed** but is display-only — it does not influence the obstacle sequence
+- **Daily best** is independent of all-time best; both are shown on the Game Over screen when in Daily Challenge
+- A **Share result** references both the **Daily number** and the **Daily best**

--- a/script.js
+++ b/script.js
@@ -457,12 +457,14 @@ const DifficultyProfile = {
     return INITIAL_SPEED + (PLATEAU_SPEED - INITIAL_SPEED) *
       (1 / (1 + Math.exp(-RAMP_STEEPNESS * (score - RAMP_MIDPOINT))));
   },
-  obstacleParamsAt(score, rng, mode) {
+  nextObstacle(score, mode, rng) {
     const speed = this.speedAtScore(score);
+    // RNG call order is load-bearing: type roll first, gap jitter second.
+    // Swapping breaks the daily-challenge seed sequence.
     const type = pickObstacleType(rng, score, mode);
     return {
-      gap:  computeNextSpawnGap(rng, speed, mode),
       type,
+      gap: computeNextSpawnGap(rng, speed, mode),
     };
   },
 };
@@ -1441,9 +1443,9 @@ function gameLoop() {
 
   // Obstacle spawning — in updated mode the gap is precomputed per-obstacle
   // with ±SPAWN_GAP_JITTER so spacing doesn't feel metronomic; in classic mode
-  // it's deterministic. See computeNextSpawnGap() / pickObstacleType().
+  // it's deterministic. DifficultyProfile.nextObstacle() picks type + gap together.
   if (game.lastObstacleX <= GAME_CONFIG.CANVAS_W - game.nextSpawnGap) {
-    const params = DifficultyProfile.obstacleParamsAt(game.score, game.rng, game.mode);
+    const params = DifficultyProfile.nextObstacle(game.score, game.mode, game.rng);
     spawnObstacle(params.type);
     game.lastObstacleX = GAME_CONFIG.CANVAS_W;
     game.nextSpawnGap = params.gap;
@@ -1546,8 +1548,6 @@ if (typeof process !== 'undefined' && process.versions && process.versions.node)
   global.initCanvasScale = initCanvasScale;
   global.handleResize   = handleResize;
   global.mulberry32 = mulberry32;
-  global.computeNextSpawnGap = computeNextSpawnGap;
-  global.pickObstacleType = pickObstacleType;
   global.MODES = MODES;
   global.setMode = setMode;
   global.loadMode = loadMode;

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -236,7 +236,7 @@ describe('Obstacle Gap Enforcement', () => {
     cancelAnimationFrame(game.animationFrameId);
     assertEquals(game.obstacles.length, 1, 'Should have 1 obstacle after first gameLoop frame');
 
-    // After spawn, nextSpawnGap was recomputed via DifficultyProfile.obstacleParamsAt(score=0)
+    // After spawn, nextSpawnGap was recomputed via DifficultyProfile.nextObstacle(score=0)
     // speedAtScore(0) ≈ 3.24, which yields baseGap 588 at rng=0.5 (zero-jitter midpoint)
     assertEquals(game.nextSpawnGap, 588, 'Next gap should be baseGap 588 at speedAtScore(0) with zero jitter');
 
@@ -256,9 +256,10 @@ describe('Obstacle Gap Enforcement', () => {
 });
 
 describe('Spawn Gap Jitter', () => {
-  it('computeNextSpawnGap stays within [MIN_SPAWN_GAP, baseGap * (1 + JITTER)]', () => {
-    const speeds = [GAME_CONFIG.INITIAL_SPEED, 3.0, GAME_CONFIG.SPEED_CAP];
-    speeds.forEach(speed => {
+  it('nextObstacle gap stays within [MIN_SPAWN_GAP, baseGap * (1 + JITTER)]', () => {
+    const scores = [0, 200, 500];
+    scores.forEach(score => {
+      const speed = DifficultyProfile.speedAtScore(score);
       const baseGap = Math.max(
         GAME_CONFIG.MIN_SPAWN_GAP,
         GAME_CONFIG.MAX_SPAWN_GAP - (speed - GAME_CONFIG.INITIAL_SPEED) * GAME_CONFIG.SPAWN_GAP_SPEED_FACTOR
@@ -266,10 +267,10 @@ describe('Spawn Gap Jitter', () => {
       const upperBound = Math.round(baseGap * (1 + GAME_CONFIG.SPAWN_GAP_JITTER));
       const rng = mulberry32(12345);
       for (let i = 0; i < 500; i++) {
-        const gap = computeNextSpawnGap(rng, speed);
+        const { gap } = DifficultyProfile.nextObstacle(score, MODES.UPDATED, rng);
         assert(
           gap >= GAME_CONFIG.MIN_SPAWN_GAP && gap <= upperBound,
-          `At speed ${speed}, gap ${gap} should be in [${GAME_CONFIG.MIN_SPAWN_GAP}, ${upperBound}]`
+          `At score ${score}, gap ${gap} should be in [${GAME_CONFIG.MIN_SPAWN_GAP}, ${upperBound}]`
         );
       }
     });
@@ -278,16 +279,16 @@ describe('Spawn Gap Jitter', () => {
   it('produces different gaps across spawns (breaks the metronome)', () => {
     const rng = mulberry32(7);
     const gaps = new Set();
-    for (let i = 0; i < 50; i++) gaps.add(computeNextSpawnGap(rng, 2.0));
+    for (let i = 0; i < 50; i++) gaps.add(DifficultyProfile.nextObstacle(100, MODES.UPDATED, rng).gap);
     assert(gaps.size >= 5, `Expected gap variety; got ${gaps.size} distinct values across 50 draws`);
   });
 
   it('smallest achievable gap is still at least MIN_SPAWN_GAP (always clearable)', () => {
-    // Exhaustively test by forcing rng to 0 (maximum negative jitter).
+    // Force rng to 0 → maximum negative jitter on the gap roll.
     const worstCaseRng = () => 0;
-    const gap = computeNextSpawnGap(worstCaseRng, GAME_CONFIG.SPEED_CAP);
+    const { gap } = DifficultyProfile.nextObstacle(500, MODES.UPDATED, worstCaseRng);
     assert(gap >= GAME_CONFIG.MIN_SPAWN_GAP,
-      `At max negative jitter + cap speed, gap ${gap} must be >= MIN_SPAWN_GAP ${GAME_CONFIG.MIN_SPAWN_GAP}`);
+      `At max negative jitter + near-plateau speed, gap ${gap} must be >= MIN_SPAWN_GAP ${GAME_CONFIG.MIN_SPAWN_GAP}`);
   });
 
   it('mulberry32 is deterministic given same seed', () => {
@@ -634,25 +635,25 @@ describe('Mode Toggle', () => {
     const rng = mulberry32(99);
     for (const score of [0, 100, 250, 1000]) {
       for (let i = 0; i < 50; i++) {
-        const t = pickObstacleType(rng, score, MODES.CLASSIC);
-        assertEquals(t.id, 'small', `Classic@${score}: expected small, got ${t.id}`);
+        const { type } = DifficultyProfile.nextObstacle(score, MODES.CLASSIC, rng);
+        assertEquals(type.id, 'small', `Classic@${score}: expected small, got ${type.id}`);
       }
     }
   });
 
   it('classic mode returns deterministic gap (no jitter)', () => {
-    const rng = () => 0; // worst-case jitter input
-    const a = computeNextSpawnGap(rng, GAME_CONFIG.INITIAL_SPEED, MODES.CLASSIC);
-    const b = computeNextSpawnGap(rng, GAME_CONFIG.INITIAL_SPEED, MODES.CLASSIC);
+    const rng = () => 0; // worst-case jitter input — should have no effect in classic
+    const a = DifficultyProfile.nextObstacle(0, MODES.CLASSIC, rng).gap;
+    const b = DifficultyProfile.nextObstacle(0, MODES.CLASSIC, rng).gap;
     assertEquals(a, b, 'Classic gap should not vary');
     assertEquals(a, GAME_CONFIG.MAX_SPAWN_GAP,
-      `At INITIAL_SPEED, classic gap should be MAX_SPAWN_GAP (${GAME_CONFIG.MAX_SPAWN_GAP}), got ${a}`);
+      `At score 0, classic gap should be MAX_SPAWN_GAP (${GAME_CONFIG.MAX_SPAWN_GAP}), got ${a}`);
   });
 
   it('updated mode still produces variety', () => {
     const rng = mulberry32(11);
     const gaps = new Set();
-    for (let i = 0; i < 30; i++) gaps.add(computeNextSpawnGap(rng, 8, MODES.UPDATED));
+    for (let i = 0; i < 30; i++) gaps.add(DifficultyProfile.nextObstacle(200, MODES.UPDATED, rng).gap);
     assert(gaps.size >= 5, `Updated mode should jitter; got ${gaps.size} distinct values`);
   });
 
@@ -671,15 +672,15 @@ describe('Obstacle Types', () => {
   it('only returns small cactus when score < 100', () => {
     const rng = mulberry32(1);
     for (let i = 0; i < 200; i++) {
-      const t = pickObstacleType(rng, 50);
-      assertEquals(t.id, 'small', `At score 50 expected small, got ${t.id}`);
+      const { type } = DifficultyProfile.nextObstacle(50, MODES.UPDATED, rng);
+      assertEquals(type.id, 'small', `At score 50 expected small, got ${type.id}`);
     }
   });
 
   it('can return big cactus at score 100+ but never cluster before 250', () => {
     const rng = mulberry32(2);
     const seen = new Set();
-    for (let i = 0; i < 500; i++) seen.add(pickObstacleType(rng, 150).id);
+    for (let i = 0; i < 500; i++) seen.add(DifficultyProfile.nextObstacle(150, MODES.UPDATED, rng).type.id);
     assert(seen.has('small') && seen.has('big'), `Expected small+big at score 150, saw ${[...seen]}`);
     assert(!seen.has('cluster'), `Cluster should not appear before score 250, saw ${[...seen]}`);
   });
@@ -687,7 +688,7 @@ describe('Obstacle Types', () => {
   it('can return all three types at score 250+', () => {
     const rng = mulberry32(3);
     const seen = new Set();
-    for (let i = 0; i < 2000; i++) seen.add(pickObstacleType(rng, 300).id);
+    for (let i = 0; i < 2000; i++) seen.add(DifficultyProfile.nextObstacle(300, MODES.UPDATED, rng).type.id);
     assert(seen.has('small') && seen.has('big') && seen.has('cluster'),
       `Expected all 3 types at score 300, saw ${[...seen]}`);
   });
@@ -696,7 +697,7 @@ describe('Obstacle Types', () => {
     const rng = mulberry32(4);
     const counts = { small: 0, big: 0, cluster: 0 };
     const total = 20000;
-    for (let i = 0; i < total; i++) counts[pickObstacleType(rng, 300).id]++;
+    for (let i = 0; i < total; i++) counts[DifficultyProfile.nextObstacle(300, MODES.UPDATED, rng).type.id]++;
     const expected = { small: 0.5, big: 0.3, cluster: 0.2 };
     Object.keys(expected).forEach(id => {
       const observed = counts[id] / total;
@@ -1529,42 +1530,42 @@ describe('DifficultyProfile', () => {
       `Speed must strictly increase: ${s0} < ${s100} < ${s300} < ${s600}`);
   });
 
-  it('obstacleParamsAt returns an object with a numeric gap and a typed obstacle', () => {
+  it('nextObstacle returns an object with a numeric gap and a typed obstacle', () => {
     const rng = mulberry32(42);
-    const params = DifficultyProfile.obstacleParamsAt(0, rng, MODES.CLASSIC);
+    const params = DifficultyProfile.nextObstacle(0, MODES.CLASSIC, rng);
     assert(typeof params.gap === 'number',
       'gap must be a number');
     assert(params.type && typeof params.type.id === 'string',
       'type must be an obstacle-type object with an id string');
   });
 
-  it('obstacleParamsAt classic mode: gap shrinks as score rises', () => {
+  it('nextObstacle classic mode: gap shrinks as score rises', () => {
     const rng = mulberry32(42); // not consumed in classic mode — safe to reuse
-    const paramsLow  = DifficultyProfile.obstacleParamsAt(0,   rng, MODES.CLASSIC);
-    const paramsHigh = DifficultyProfile.obstacleParamsAt(500, rng, MODES.CLASSIC);
+    const paramsLow  = DifficultyProfile.nextObstacle(0,   MODES.CLASSIC, rng);
+    const paramsHigh = DifficultyProfile.nextObstacle(500, MODES.CLASSIC, rng);
     assert(paramsHigh.gap < paramsLow.gap,
       `Gap at score 500 (${paramsHigh.gap}) should be less than gap at score 0 (${paramsLow.gap}) — higher speed means shorter gap`);
   });
 
-  it('obstacleParamsAt classic mode: type is always small cactus', () => {
+  it('nextObstacle classic mode: type is always small cactus', () => {
     const rng = mulberry32(42);
-    const params = DifficultyProfile.obstacleParamsAt(500, rng, MODES.CLASSIC);
+    const params = DifficultyProfile.nextObstacle(500, MODES.CLASSIC, rng);
     assertEquals(params.type.id, 'small',
       'Classic mode must always return the small cactus');
   });
 
-  it('obstacleParamsAt updated mode: gap is within valid range at score 0', () => {
+  it('nextObstacle updated mode: gap is within valid range at score 0', () => {
     const rng = mulberry32(42);
-    const params = DifficultyProfile.obstacleParamsAt(0, rng, MODES.UPDATED);
+    const params = DifficultyProfile.nextObstacle(0, MODES.UPDATED, rng);
     assert(params.gap >= GAME_CONFIG.MIN_SPAWN_GAP,
       `Gap (${params.gap}) must be at least MIN_SPAWN_GAP (${GAME_CONFIG.MIN_SPAWN_GAP})`);
     assert(params.gap <= Math.round(GAME_CONFIG.MAX_SPAWN_GAP * (1 + GAME_CONFIG.SPAWN_GAP_JITTER)),
       `Gap (${params.gap}) must not exceed MAX_SPAWN_GAP with max jitter (${GAME_CONFIG.MAX_SPAWN_GAP} * ${1 + GAME_CONFIG.SPAWN_GAP_JITTER})`);
   });
 
-  it('obstacleParamsAt updated mode: cluster cactus returned at score 250 with max roll', () => {
+  it('nextObstacle updated mode: cluster cactus returned at score 250 with max roll', () => {
     const rng = () => 0.99; // constant roll — pushes weighted pick to last eligible type
-    const params = DifficultyProfile.obstacleParamsAt(250, rng, MODES.UPDATED);
+    const params = DifficultyProfile.nextObstacle(250, MODES.UPDATED, rng);
     assertEquals(params.type.id, 'cluster',
       'At score 250 with max rng roll, all three types eligible and cluster wins the weighted draw');
   });
@@ -1939,10 +1940,10 @@ describe('Daily mode RNG seeding', () => {
     const origMode = game.mode;
     game.mode = MODES.DAILY;
     resetGame();
-    const type1 = pickObstacleType(game.rng, 300, MODES.DAILY);
+    const type1 = DifficultyProfile.nextObstacle(300, MODES.DAILY, game.rng).type;
     game.mode = MODES.DAILY;
     resetGame();
-    const type2 = pickObstacleType(game.rng, 300, MODES.DAILY);
+    const type2 = DifficultyProfile.nextObstacle(300, MODES.DAILY, game.rng).type;
     assertEquals(type1.id, type2.id, 'Same seed should produce same obstacle type');
     game.mode = origMode;
     resetGame();


### PR DESCRIPTION
## Summary

- Renames `obstacleParamsAt(score, rng, mode)` → `nextObstacle(score, mode, rng)` on `DifficultyProfile`, absorbing the two standalone helpers (`pickObstacleType`, `computeNextSpawnGap`) as implementation details
- Callers now call one method and get `{ type, gap }` back — no longer need to know that gap depends on speed, which depends on score
- Both helpers remain as file-scope functions (used internally and in `resetGame`) but are removed from the Section 10 test-exposure block
- RNG call order preserved exactly (type roll first, gap jitter second) and documented — swapping would break daily-challenge seed sequences
- 11 tests that called the old helpers directly are rewritten to assert on the `nextObstacle` interface
- CLAUDE.md Section 6 description and CONTEXT.md Daily Challenge terms updated

## Test plan

- [ ] CI passes (all existing tests green under new interface)
- [ ] `DifficultyProfile` describe block: 5 tests renamed `obstacleParamsAt` → `nextObstacle`
- [ ] `Spawn Gap Jitter` describe: 3 tests rewritten using score-based calls
- [ ] `Classic Mode` describe: 3 tests rewritten
- [ ] `Obstacle Types` describe: 4 tests rewritten
- [ ] `Daily mode RNG seeding` describe: 1 test updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)