### PR TITLE
refactor: extract animation counters into Animations module

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -12,6 +12,8 @@
 
 **Particles** — the module that owns the particle pool, kind definitions, and all emit/update/draw/reset behaviour. Callers invoke `Particles.emit(kind, x, y)` without knowing pool size, reduced-motion rules, or mode gating — all suppression logic lives inside. Visual-only: uses `Math.random()`, never `game.rng()`.
 
+**Animations** — the module that owns all per-run animation countdown timers (death shake, death flash, score pop, milestone flash, new-best badge, copy flash, death score count-up). A single `Animations.reset()` call zeroes all counters at the start of each run. Handlers and draw functions read and write counters directly via `Animations.X`.
+
 ## Daily Challenge
 
 **Daily Challenge** — a play mode in which the obstacle sequence is seeded from the current calendar date, giving every player the same run each day. Activated by a dedicated button; always runs in Updated mode.

--- a/script.js
+++ b/script.js
@@ -529,20 +529,30 @@ const game = {
   stars:            [],
   starsInitialised: false,
   hills:            [],
-  deathAnimFrame:   0,
-  deathShakeFrames: 0,
-  deathFlashFrames: 0,
-  scorePopFrames:   0,
   milestoneText:    '',
-  milestoneFrames:  0,
-  newBestFrames:    0,
   newBestShown:     false,
   isNewBest:         false,
   previousHighScore: 0,
   rng:              mulberry32(Date.now() & 0xffffffff),
   mode:             loadMode(),
   dailyBest:        ScoreStore.loadDailyBest(),
+};
+
+// All per-run animation countdown timers. Kept separate from the game object
+// so reset() is a single call and adding a new timer has exactly one place.
+const Animations = {
+  deathAnimFrame:   0,
+  deathShakeFrames: 0,
+  deathFlashFrames: 0,
+  scorePopFrames:   0,
+  milestoneFrames:  0,
+  newBestFrames:    0,
   copyFlashFrames:  0,
+  reset() {
+    this.deathAnimFrame = this.deathShakeFrames = this.deathFlashFrames = 0;
+    this.scorePopFrames = this.milestoneFrames  = this.newBestFrames    = 0;
+    this.copyFlashFrames = 0;
+  },
 };
 
 function setMode(newMode) {
@@ -690,8 +700,8 @@ function drawHills() {
 // the existing day/night background.
 function drawSkyTint() {
   if (!isUpdatedMode() || reducedMotion) return;
-  if (game.milestoneFrames <= 0) return;
-  const alpha = (game.milestoneFrames / GAME_CONFIG.MILESTONE_FRAMES) * cfg('SKY_TINT_PEAK_ALPHA');
+  if (Animations.milestoneFrames <= 0) return;
+  const alpha = (Animations.milestoneFrames / GAME_CONFIG.MILESTONE_FRAMES) * cfg('SKY_TINT_PEAK_ALPHA');
   ctx.save();
   ctx.fillStyle = 'rgba(' + cfg('SKY_TINT_COLOR_RGB') + ', ' + alpha.toFixed(3) + ')';
   ctx.fillRect(0, 0, GAME_CONFIG.CANVAS_W, GAME_CONFIG.CANVAS_H);
@@ -758,10 +768,10 @@ function drawDino() {
 }
 
 function drawScore() {
-  const popping = game.scorePopFrames > 0 && isUpdatedMode() && !reducedMotion;
+  const popping = Animations.scorePopFrames > 0 && isUpdatedMode() && !reducedMotion;
   if (popping) {
     // Brief 1.0 → 1.4 ease-out scale around the score's centre on death.
-    const t = game.scorePopFrames / GAME_CONFIG.SCORE_POP_FRAMES; // 1 → 0
+    const t = Animations.scorePopFrames / GAME_CONFIG.SCORE_POP_FRAMES; // 1 → 0
     const scale = 1 + t * 0.4;
     const cx = GAME_CONFIG.CANVAS_W - GAME_CONFIG.SCORE_X_OFFSET + 30;
     const cy = GAME_CONFIG.SCORE_Y - 8;
@@ -804,8 +814,8 @@ function drawScore() {
 // PR-C: white-flash overlay drawn on top of the world during the first few
 // post-death frames. Mode-gated; reduce-motion caps it at 1 frame.
 function drawDeathFlash() {
-  if (game.deathFlashFrames <= 0) return;
-  const alpha = game.deathFlashFrames / cfg('DEATH_FLASH_FRAMES');
+  if (Animations.deathFlashFrames <= 0) return;
+  const alpha = Animations.deathFlashFrames / cfg('DEATH_FLASH_FRAMES');
   ctx.save();
   ctx.fillStyle = 'rgba(' + cfg('DEATH_FLASH_COLOR_RGB') + ', ' + alpha.toFixed(3) + ')';
   ctx.fillRect(0, 0, GAME_CONFIG.CANVAS_W, GAME_CONFIG.CANVAS_H);
@@ -846,7 +856,7 @@ function drawGetReadyOverlay() {
 
 function drawGameOverScreen() {
   const font = cfg('SCORE_FONT_FAMILY');
-  const t = Math.min(game.deathAnimFrame / GAME_CONFIG.DEATH_ANIM_FRAMES, 1);
+  const t = Math.min(Animations.deathAnimFrame / GAME_CONFIG.DEATH_ANIM_FRAMES, 1);
   const displayScore = Math.round(t * Math.floor(game.score));
 
   ctx.fillStyle = 'rgba(0, 0, 0, 0.75)';
@@ -890,7 +900,7 @@ function drawGameOverScreen() {
     if (shareBtnEl && shareBtnEl.style) {
       shareBtnEl.style.display = t >= 1 ? 'block' : 'none';
       if (t >= 1) {
-        shareBtnEl.textContent = game.copyFlashFrames > 0 ? '✓ Copied!' : '📋 Copy result';
+        shareBtnEl.textContent = Animations.copyFlashFrames > 0 ? '✓ Copied!' : '📋 Copy result';
       }
     }
   } else {
@@ -944,30 +954,30 @@ function drawGameOverScreen() {
 }
 
 function drawMilestoneFlash() {
-  if (game.milestoneFrames <= 0) return;
+  if (Animations.milestoneFrames <= 0) return;
   ctx.save();
-  ctx.globalAlpha = game.milestoneFrames / GAME_CONFIG.MILESTONE_FRAMES;
+  ctx.globalAlpha = Animations.milestoneFrames / GAME_CONFIG.MILESTONE_FRAMES;
   ctx.fillStyle = game.score >= GAME_CONFIG.DAY_NIGHT_START ? '#ffffff' : '#000000';
   ctx.textAlign = 'center';
   ctx.font = 'bold 22px ' + cfg('SCORE_FONT_FAMILY');
   ctx.fillText(game.milestoneText, GAME_CONFIG.CANVAS_W / 2, GAME_CONFIG.CANVAS_H / 2 - 30);
   ctx.restore();
-  game.milestoneFrames--;
+  Animations.milestoneFrames--;
 }
 
 function drawNewBestBadge() {
-  if (game.newBestFrames <= 0) return;
+  if (Animations.newBestFrames <= 0) return;
   ctx.save();
-  ctx.globalAlpha = game.newBestFrames / GAME_CONFIG.NEW_BEST_FRAMES;
+  ctx.globalAlpha = Animations.newBestFrames / GAME_CONFIG.NEW_BEST_FRAMES;
   ctx.fillStyle = '#ffd700';
   ctx.textAlign = 'left';
   ctx.font = 'bold 14px ' + cfg('SCORE_FONT_FAMILY');
   // Drop below the milestone flash when both fire on the same frame
   // (level-up + new-best at score = highScore + 100).
-  const y = game.milestoneFrames > 0 ? 100 : 70;
+  const y = Animations.milestoneFrames > 0 ? 100 : 70;
   ctx.fillText('NEW BEST!', GAME_CONFIG.CANVAS_W - GAME_CONFIG.SCORE_X_OFFSET, y);
   ctx.restore();
-  game.newBestFrames--;
+  Animations.newBestFrames--;
 }
 
 // --- Particle system (PR-A) ---
@@ -1137,8 +1147,8 @@ function handleAction() {
   } else if (game.state === STATE.RUNNING) {
     jump();
   } else if (game.state === STATE.DEAD) {
-    if (game.deathAnimFrame < GAME_CONFIG.DEATH_ANIM_FRAMES) {
-      game.deathAnimFrame = GAME_CONFIG.DEATH_ANIM_FRAMES;
+    if (Animations.deathAnimFrame < GAME_CONFIG.DEATH_ANIM_FRAMES) {
+      Animations.deathAnimFrame = GAME_CONFIG.DEATH_ANIM_FRAMES;
       drawGameOverScreen();
     } else {
       resetGame();
@@ -1233,7 +1243,7 @@ if (shareBtn && shareBtn.addEventListener) {
   const onShareTap = (event) => {
     if (event) event.stopPropagation();
     shareDailyResult();
-    game.copyFlashFrames = 90; // ~1.5 s at 60 fps
+    Animations.copyFlashFrames = 90; // ~1.5 s at 60 fps
   };
   shareBtn.addEventListener('click', onShareTap);
   shareBtn.addEventListener('touchstart', (event) => {
@@ -1316,18 +1326,12 @@ function resetGame() {
   game.graceFrames = GAME_CONFIG.GRACE_FRAMES;
   game.state = STATE.WAITING;
   game.starsInitialised = false;
-  game.deathAnimFrame   = 0;
-  game.deathShakeFrames = 0;
-  game.deathFlashFrames = 0;
-  game.scorePopFrames   = 0;
-  game.milestoneFrames = 0;
-  game.newBestFrames     = 0;
+  Animations.reset();
   game.newBestShown      = false;
   game.isNewBest         = false;
   game.previousHighScore = 0;
   game.rng = mulberry32(isDailyMode() ? dailySeed() : (Date.now() & 0xffffffff));
   game.dailyBest = ScoreStore.loadDailyBest();
-  game.copyFlashFrames = 0;
   const shareBtnEl = document.getElementById('share-btn');
   if (shareBtnEl && shareBtnEl.style) shareBtnEl.style.display = 'none';
   game.nextSpawnGap = computeNextSpawnGap(game.rng, DifficultyProfile.speedAtScore(game.score), game.mode);
@@ -1338,9 +1342,9 @@ function resetGame() {
 }
 
 function handleDead() {
-  if (game.deathShakeFrames > 0) {
+  if (Animations.deathShakeFrames > 0) {
     ctx.save();
-    ctx.translate(Math.sin(game.deathShakeFrames * cfg('DEATH_SHAKE_FREQ')) * cfg('DEATH_SHAKE_AMPLITUDE'), 0);
+    ctx.translate(Math.sin(Animations.deathShakeFrames * cfg('DEATH_SHAKE_FREQ')) * cfg('DEATH_SHAKE_AMPLITUDE'), 0);
     drawBackground();
     drawHills();
     drawGround();
@@ -1352,14 +1356,14 @@ function handleDead() {
     ctx.restore();
     drawDeathFlash(); // white flash drawn outside the shake transform so it stays canvas-aligned
     Particles.update();
-    if (game.deathFlashFrames > 0) game.deathFlashFrames--;
-    if (game.scorePopFrames > 0) game.scorePopFrames--;
-    game.deathShakeFrames--;
-  } else if (game.deathAnimFrame < GAME_CONFIG.DEATH_ANIM_FRAMES) {
-    game.deathAnimFrame++;
+    if (Animations.deathFlashFrames > 0) Animations.deathFlashFrames--;
+    if (Animations.scorePopFrames > 0) Animations.scorePopFrames--;
+    Animations.deathShakeFrames--;
+  } else if (Animations.deathAnimFrame < GAME_CONFIG.DEATH_ANIM_FRAMES) {
+    Animations.deathAnimFrame++;
     drawGameOverScreen();
   } else {
-    if (game.copyFlashFrames > 0) game.copyFlashFrames--;
+    if (Animations.copyFlashFrames > 0) Animations.copyFlashFrames--;
     drawGameOverScreen();
   }
 }
@@ -1405,7 +1409,7 @@ function handleRunning() {
   // Milestone flash on level-up.
   if (level > prevLevel && level > 0) {
     game.milestoneText = 'LEVEL ' + (level + 1);
-    game.milestoneFrames = GAME_CONFIG.MILESTONE_FRAMES;
+    Animations.milestoneFrames = GAME_CONFIG.MILESTONE_FRAMES;
     audio.milestone();
     Particles.emit('confetti', GAME_CONFIG.CANVAS_W - GAME_CONFIG.SCORE_X_OFFSET + 30, GAME_CONFIG.SCORE_Y);
   }
@@ -1451,11 +1455,11 @@ function handleRunning() {
   for (let i = 0; i < game.obstacles.length; i++) {
     if (checkCollision(dino, game.obstacles[i])) {
       game.state = STATE.DEAD;
-      game.deathShakeFrames = GAME_CONFIG.DEATH_SHAKE_FRAMES;
+      Animations.deathShakeFrames = GAME_CONFIG.DEATH_SHAKE_FRAMES;
       // PR-C: white flash + score pop, mode-gated. Reduce-motion caps flash to 1 frame.
       if (isUpdatedMode()) {
-        game.deathFlashFrames = reducedMotion ? 1 : GAME_CONFIG.DEATH_FLASH_FRAMES;
-        game.scorePopFrames = reducedMotion ? 0 : GAME_CONFIG.SCORE_POP_FRAMES;
+        Animations.deathFlashFrames = reducedMotion ? 1 : GAME_CONFIG.DEATH_FLASH_FRAMES;
+        Animations.scorePopFrames = reducedMotion ? 0 : GAME_CONFIG.SCORE_POP_FRAMES;
       }
       Particles.emit('collision', dino.x + dino.width / 2, dino.y + dino.height / 2);
       audio.death();
@@ -1493,7 +1497,7 @@ function handleRunning() {
   // NEW BEST badge — first time this run's score exceeds the stored high score.
   if (!game.newBestShown && game.highScore > 0 && Math.floor(game.score) > game.highScore) {
     game.newBestShown = true;
-    game.newBestFrames = GAME_CONFIG.NEW_BEST_FRAMES;
+    Animations.newBestFrames = GAME_CONFIG.NEW_BEST_FRAMES;
     announce('New best score!');
   }
 
@@ -1527,6 +1531,7 @@ if (typeof process !== 'undefined' && process.versions && process.versions.node)
   global.GAME_CONFIG = GAME_CONFIG;
   global.STATE = STATE;
   global.game = game;
+  global.Animations = Animations;
   global.canvas = canvas;
   global.ctx = ctx;
   global.dino = dino;

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -400,8 +400,8 @@ describe('Death flash + score pop (PR-C)', () => {
     gameLoop();
     cancelAnimationFrame(game.animationFrameId);
     assertEquals(game.state, STATE.DEAD, 'should be dead');
-    assertEquals(game.deathFlashFrames, GAME_CONFIG.DEATH_FLASH_FRAMES, 'flash counter set');
-    assertEquals(game.scorePopFrames, GAME_CONFIG.SCORE_POP_FRAMES, 'score pop counter set');
+    assertEquals(Animations.deathFlashFrames, GAME_CONFIG.DEATH_FLASH_FRAMES, 'flash counter set');
+    assertEquals(Animations.scorePopFrames, GAME_CONFIG.SCORE_POP_FRAMES, 'score pop counter set');
   });
 
   it('classic mode collision leaves deathFlashFrames + scorePopFrames at 0', () => {
@@ -413,8 +413,8 @@ describe('Death flash + score pop (PR-C)', () => {
     game.obstacles.push({ x: dino.x, y: GAME_CONFIG.CANVAS_H - 40, width: 20, height: 40 });
     gameLoop();
     cancelAnimationFrame(game.animationFrameId);
-    assertEquals(game.deathFlashFrames, 0, 'classic should not flash');
-    assertEquals(game.scorePopFrames, 0, 'classic should not pop');
+    assertEquals(Animations.deathFlashFrames, 0, 'classic should not flash');
+    assertEquals(Animations.scorePopFrames, 0, 'classic should not pop');
     setMode(MODES.UPDATED); // reset for siblings
     cancelAnimationFrame(game.animationFrameId);
   });
@@ -433,18 +433,18 @@ describe('Death flash + score pop (PR-C)', () => {
       gameLoop();
       cancelAnimationFrame(game.animationFrameId);
     }
-    assertEquals(game.deathFlashFrames, 0, 'flash should decay to 0');
+    assertEquals(Animations.deathFlashFrames, 0, 'flash should decay to 0');
   });
 
   it('resetGame clears deathFlashFrames + scorePopFrames', () => {
     setMode(MODES.UPDATED);
     cancelAnimationFrame(game.animationFrameId);
-    game.deathFlashFrames = 6;
-    game.scorePopFrames = 12;
+    Animations.deathFlashFrames = 6;
+    Animations.scorePopFrames = 12;
     resetGame();
     cancelAnimationFrame(game.animationFrameId);
-    assertEquals(game.deathFlashFrames, 0, 'reset clears flash');
-    assertEquals(game.scorePopFrames, 0, 'reset clears pop');
+    assertEquals(Animations.deathFlashFrames, 0, 'reset clears flash');
+    assertEquals(Animations.scorePopFrames, 0, 'reset clears pop');
   });
 });
 
@@ -879,7 +879,7 @@ describe('State Transitions', () => {
     cancelAnimationFrame(game.animationFrameId);
 
     assertEquals(game.state, STATE.DEAD, 'State should flip to DEAD on collision');
-    assert(game.deathShakeFrames > 0, 'Death shake should be queued');
+    assert(Animations.deathShakeFrames > 0, 'Death shake should be queued');
   });
 
   it('DEAD → WAITING via resetGame restores gameplay fields', () => {
@@ -896,7 +896,7 @@ describe('State Transitions', () => {
     assertEquals(game.state, STATE.WAITING, 'resetGame should put state back to WAITING');
     assertEquals(game.score, 0, 'score should be cleared');
     assertEquals(game.obstacles.length, 0, 'obstacles should be cleared');
-    assertEquals(game.deathShakeFrames, 0, 'deathShakeFrames should be cleared');
+    assertEquals(Animations.deathShakeFrames, 0, 'deathShakeFrames should be cleared');
   });
 });
 
@@ -943,13 +943,13 @@ describe('PR-P1 bug fixes', () => {
     const origFill = ctx.fillText;
     ctx.fillText = (text, x, y) => calls.push({ text, x, y });
 
-    game.milestoneFrames = 0;
-    game.newBestFrames = GAME_CONFIG.NEW_BEST_FRAMES;
+    Animations.milestoneFrames = 0;
+    Animations.newBestFrames = GAME_CONFIG.NEW_BEST_FRAMES;
     drawNewBestBadge();
     const baseY = calls[calls.length - 1].y;
 
-    game.milestoneFrames = GAME_CONFIG.MILESTONE_FRAMES;
-    game.newBestFrames = GAME_CONFIG.NEW_BEST_FRAMES;
+    Animations.milestoneFrames = GAME_CONFIG.MILESTONE_FRAMES;
+    Animations.newBestFrames = GAME_CONFIG.NEW_BEST_FRAMES;
     drawNewBestBadge();
     const offsetY = calls[calls.length - 1].y;
 
@@ -958,8 +958,8 @@ describe('PR-P1 bug fixes', () => {
     assertEquals(offsetY - baseY, 30, 'Stagger should be exactly 30px');
 
     ctx.fillText = origFill;
-    game.milestoneFrames = 0;
-    game.newBestFrames = 0;
+    Animations.milestoneFrames = 0;
+    Animations.newBestFrames = 0;
   });
 });
 
@@ -1122,7 +1122,7 @@ describe('Live-tuning hook (PR-P3)', () => {
     //   isUpdatedMode() && !reducedMotion && milestoneFrames > 0.
     // The Node stub's matchMedia returns matches:false so reducedMotion is
     // always false here — no need to guard.
-    game.milestoneFrames = GAME_CONFIG.MILESTONE_FRAMES;
+    Animations.milestoneFrames = GAME_CONFIG.MILESTONE_FRAMES;
 
     const fillStyles = [];
     const proto = Object.getPrototypeOf(ctx);
@@ -1143,7 +1143,7 @@ describe('Live-tuning hook (PR-P3)', () => {
     const blueish = fillStyles.find(s => typeof s === 'string' && s.indexOf('rgba(0, 0, 255') === 0);
     assert(blueish, `Expected a fillStyle starting with 'rgba(0, 0, 255' but got: ${JSON.stringify(fillStyles)}`);
 
-    game.milestoneFrames = 0;
+    Animations.milestoneFrames = 0;
   });
 });
 
@@ -1153,15 +1153,15 @@ describe('HUD score format (polish pass)', () => {
     const origFill = ctx.fillText;
     ctx.fillText = (text) => calls.push(String(text));
     const origScore = game.score;
-    const origPop = game.scorePopFrames;
+    const origPop = Animations.scorePopFrames;
     const origHS = game.highScore;
     game.score = 42;
-    game.scorePopFrames = 0;
+    Animations.scorePopFrames = 0;
     game.highScore = 0;
     drawScore();
     ctx.fillText = origFill;
     game.score = origScore;
-    game.scorePopFrames = origPop;
+    Animations.scorePopFrames = origPop;
     game.highScore = origHS;
     assert(calls.some(t => t === '00042'),
       `Expected '00042' in HUD calls, got: ${JSON.stringify(calls)}`);
@@ -1175,15 +1175,15 @@ describe('HUD score format (polish pass)', () => {
     ctx.fillText = (text) => calls.push(String(text));
     const origHS = game.highScore;
     const origScore = game.score;
-    const origPop = game.scorePopFrames;
+    const origPop = Animations.scorePopFrames;
     game.highScore = 150;
     game.score = 42;
-    game.scorePopFrames = 0;
+    Animations.scorePopFrames = 0;
     drawScore();
     ctx.fillText = origFill;
     game.highScore = origHS;
     game.score = origScore;
-    game.scorePopFrames = origPop;
+    Animations.scorePopFrames = origPop;
     assert(calls.some(t => t.startsWith('HI ')),
       `Expected 'HI ...' label in HUD, got: ${JSON.stringify(calls)}`);
   });
@@ -1194,15 +1194,15 @@ describe('HUD score format (polish pass)', () => {
     ctx.fillText = (text) => calls.push(String(text));
     const origHS = game.highScore;
     const origScore = game.score;
-    const origPop = game.scorePopFrames;
+    const origPop = Animations.scorePopFrames;
     game.highScore = 0;
     game.score = 42;
-    game.scorePopFrames = 0;
+    Animations.scorePopFrames = 0;
     drawScore();
     ctx.fillText = origFill;
     game.highScore = origHS;
     game.score = origScore;
-    game.scorePopFrames = origPop;
+    Animations.scorePopFrames = origPop;
     assert(!calls.some(t => t.startsWith('HI ')),
       `Expected no 'HI ...' label when highScore is 0, got: ${JSON.stringify(calls)}`);
   });
@@ -1213,14 +1213,14 @@ describe('Game over screen (polish pass)', () => {
     const calls = [];
     const origFill      = ctx.fillText;
     const origScore     = game.score;
-    const origAnimFrame = game.deathAnimFrame;
+    const origAnimFrame = Animations.deathAnimFrame;
     ctx.fillText = (text) => calls.push(String(text));
     game.score          = 87;
-    game.deathAnimFrame = GAME_CONFIG.DEATH_ANIM_FRAMES;
+    Animations.deathAnimFrame = GAME_CONFIG.DEATH_ANIM_FRAMES;
     drawGameOverScreen();
     ctx.fillText        = origFill;
     game.score          = origScore;
-    game.deathAnimFrame = origAnimFrame;
+    Animations.deathAnimFrame = origAnimFrame;
     assert(calls.some(t => t === '00087'),
       `Expected '00087' on game over screen, got: ${JSON.stringify(calls)}`);
     assert(!calls.some(t => t.includes('Score:')),
@@ -1234,20 +1234,20 @@ describe('Game over screen (polish pass)', () => {
     const origPrevHS    = game.previousHighScore;
     const origHS        = game.highScore;
     const origScore     = game.score;
-    const origAnimFrame = game.deathAnimFrame;
+    const origAnimFrame = Animations.deathAnimFrame;
     ctx.fillText = (text) => calls.push(String(text));
     game.isNewBest         = true;
     game.previousHighScore = 0;
     game.highScore         = 0;
     game.score             = 500;
-    game.deathAnimFrame    = GAME_CONFIG.DEATH_ANIM_FRAMES;
+    Animations.deathAnimFrame    = GAME_CONFIG.DEATH_ANIM_FRAMES;
     drawGameOverScreen();
     ctx.fillText           = origFill;
     game.isNewBest         = origNewBest;
     game.previousHighScore = origPrevHS;
     game.highScore         = origHS;
     game.score             = origScore;
-    game.deathAnimFrame    = origAnimFrame;
+    Animations.deathAnimFrame    = origAnimFrame;
     assert(!calls.some(t => t === 'YOUR BEST'),
       `Expected no 'YOUR BEST' on first-run new record screen, got: ${JSON.stringify(calls)}`);
     assert(!calls.some(t => t.includes('over your previous best')),
@@ -1259,16 +1259,16 @@ describe('Game over screen (polish pass)', () => {
     const origFill      = ctx.fillText;
     const origNewBest   = game.isNewBest;
     const origHS        = game.highScore;
-    const origAnimFrame = game.deathAnimFrame;
+    const origAnimFrame = Animations.deathAnimFrame;
     ctx.fillText = (text) => calls.push(String(text));
     game.isNewBest      = false;
     game.highScore      = 250;
-    game.deathAnimFrame = GAME_CONFIG.DEATH_ANIM_FRAMES;
+    Animations.deathAnimFrame = GAME_CONFIG.DEATH_ANIM_FRAMES;
     drawGameOverScreen();
     ctx.fillText        = origFill;
     game.isNewBest      = origNewBest;
     game.highScore      = origHS;
-    game.deathAnimFrame = origAnimFrame;
+    Animations.deathAnimFrame = origAnimFrame;
     assert(calls.some(t => t === 'YOUR BEST'),
       `Expected 'YOUR BEST' in normal death side-by-side, got: ${JSON.stringify(calls)}`);
   });
@@ -1375,12 +1375,12 @@ describe('Death screen', () => {
     const origNewBest   = game.isNewBest;
     const origHS        = game.highScore;
     const origScore     = game.score;
-    const origAnimFrame = game.deathAnimFrame;
+    const origAnimFrame = Animations.deathAnimFrame;
 
     game.isNewBest      = false;
     game.highScore      = 1050;
     game.score          = 847;
-    game.deathAnimFrame = GAME_CONFIG.DEATH_ANIM_FRAMES;
+    Animations.deathAnimFrame = GAME_CONFIG.DEATH_ANIM_FRAMES;
 
     const calls = [];
     const origFill = ctx.fillText;
@@ -1391,7 +1391,7 @@ describe('Death screen', () => {
     game.isNewBest      = origNewBest;
     game.highScore      = origHS;
     game.score          = origScore;
-    game.deathAnimFrame = origAnimFrame;
+    Animations.deathAnimFrame = origAnimFrame;
 
     assert(calls.some(t => t === 'THIS RUN'),
       `Expected 'THIS RUN' in drawGameOverScreen calls, got: ${JSON.stringify(calls)}`);
@@ -1401,12 +1401,12 @@ describe('Death screen', () => {
     const origNewBest   = game.isNewBest;
     const origHS        = game.highScore;
     const origScore     = game.score;
-    const origAnimFrame = game.deathAnimFrame;
+    const origAnimFrame = Animations.deathAnimFrame;
 
     game.isNewBest      = false;
     game.highScore      = 1050;
     game.score          = 847;
-    game.deathAnimFrame = GAME_CONFIG.DEATH_ANIM_FRAMES;
+    Animations.deathAnimFrame = GAME_CONFIG.DEATH_ANIM_FRAMES;
 
     const calls = [];
     const origFill = ctx.fillText;
@@ -1417,7 +1417,7 @@ describe('Death screen', () => {
     game.isNewBest      = origNewBest;
     game.highScore      = origHS;
     game.score          = origScore;
-    game.deathAnimFrame = origAnimFrame;
+    Animations.deathAnimFrame = origAnimFrame;
 
     assert(calls.some(t => t.includes('203')),
       `Expected a call containing '203' (the gap delta), got: ${JSON.stringify(calls)}`);
@@ -1427,12 +1427,12 @@ describe('Death screen', () => {
     const origNewBest   = game.isNewBest;
     const origPrevHS    = game.previousHighScore;
     const origScore     = game.score;
-    const origAnimFrame = game.deathAnimFrame;
+    const origAnimFrame = Animations.deathAnimFrame;
 
     game.isNewBest         = true;
     game.previousHighScore = 1050;
     game.score             = 1253;
-    game.deathAnimFrame    = GAME_CONFIG.DEATH_ANIM_FRAMES;
+    Animations.deathAnimFrame    = GAME_CONFIG.DEATH_ANIM_FRAMES;
 
     const calls = [];
     const origFill = ctx.fillText;
@@ -1443,7 +1443,7 @@ describe('Death screen', () => {
     game.isNewBest         = origNewBest;
     game.previousHighScore = origPrevHS;
     game.score             = origScore;
-    game.deathAnimFrame    = origAnimFrame;
+    Animations.deathAnimFrame    = origAnimFrame;
 
     assert(calls.some(t => t.includes('NEW BEST')),
       `Expected a call containing 'NEW BEST', got: ${JSON.stringify(calls)}`);
@@ -1750,15 +1750,15 @@ describe('Orientation resize', () => {
 describe('Score count-up animation', () => {
   it('resetGame resets deathAnimFrame to 0', () => {
     const origState      = game.state;
-    const origAnimFrame  = game.deathAnimFrame;
+    const origAnimFrame  = Animations.deathAnimFrame;
 
-    game.deathAnimFrame = GAME_CONFIG.DEATH_ANIM_FRAMES;
+    Animations.deathAnimFrame = GAME_CONFIG.DEATH_ANIM_FRAMES;
     resetGame();
 
-    const resetFrame = game.deathAnimFrame;
+    const resetFrame = Animations.deathAnimFrame;
 
     game.state          = origState;
-    game.deathAnimFrame = origAnimFrame;
+    Animations.deathAnimFrame = origAnimFrame;
 
     assertEquals(resetFrame, 0,
       'resetGame should reset deathAnimFrame to 0');
@@ -1766,17 +1766,17 @@ describe('Score count-up animation', () => {
 
   it('handleAction in DEAD restarts game when animation is complete', () => {
     const origState      = game.state;
-    const origAnimFrame  = game.deathAnimFrame;
+    const origAnimFrame  = Animations.deathAnimFrame;
 
     game.state          = STATE.DEAD;
-    game.deathAnimFrame = GAME_CONFIG.DEATH_ANIM_FRAMES;
+    Animations.deathAnimFrame = GAME_CONFIG.DEATH_ANIM_FRAMES;
 
     handleAction();
 
     const newState = game.state;
 
     game.state          = origState;
-    game.deathAnimFrame = origAnimFrame;
+    Animations.deathAnimFrame = origAnimFrame;
 
     assertEquals(newState, STATE.WAITING,
       'handleAction after animation completes should transition to STATE.WAITING (via resetGame)');
@@ -1784,19 +1784,19 @@ describe('Score count-up animation', () => {
 
   it('handleAction in DEAD snaps deathAnimFrame to DEATH_ANIM_FRAMES when animation is in progress', () => {
     const origState      = game.state;
-    const origAnimFrame  = game.deathAnimFrame;
+    const origAnimFrame  = Animations.deathAnimFrame;
     const origScore      = game.score;
 
     game.state          = STATE.DEAD;
-    game.deathAnimFrame = 10;
+    Animations.deathAnimFrame = 10;
     game.score          = 500;
 
     handleAction();
 
-    const snappedFrame = game.deathAnimFrame;
+    const snappedFrame = Animations.deathAnimFrame;
 
     game.state          = origState;
-    game.deathAnimFrame = origAnimFrame;
+    Animations.deathAnimFrame = origAnimFrame;
     game.score          = origScore;
 
     assertEquals(snappedFrame, GAME_CONFIG.DEATH_ANIM_FRAMES,
@@ -1807,12 +1807,12 @@ describe('Score count-up animation', () => {
     const origScore      = game.score;
     const origNewBest    = game.isNewBest;
     const origHS         = game.highScore;
-    const origAnimFrame  = game.deathAnimFrame;
+    const origAnimFrame  = Animations.deathAnimFrame;
 
     game.score          = 500;
     game.isNewBest      = false;
     game.highScore      = 1000;
-    game.deathAnimFrame = GAME_CONFIG.DEATH_ANIM_FRAMES;
+    Animations.deathAnimFrame = GAME_CONFIG.DEATH_ANIM_FRAMES;
 
     const calls = [];
     const origFill = ctx.fillText;
@@ -1823,7 +1823,7 @@ describe('Score count-up animation', () => {
     game.score         = origScore;
     game.isNewBest     = origNewBest;
     game.highScore     = origHS;
-    game.deathAnimFrame = origAnimFrame;
+    Animations.deathAnimFrame = origAnimFrame;
 
     assert(calls.some(t => t === '00500'),
       `Expected '00500' (full score at final frame), got: ${JSON.stringify(calls)}`);
@@ -1833,12 +1833,12 @@ describe('Score count-up animation', () => {
     const origScore      = game.score;
     const origNewBest    = game.isNewBest;
     const origHS         = game.highScore;
-    const origAnimFrame  = game.deathAnimFrame;
+    const origAnimFrame  = Animations.deathAnimFrame;
 
     game.score         = 500;
     game.isNewBest     = false;
     game.highScore     = 1000;
-    game.deathAnimFrame = 0;
+    Animations.deathAnimFrame = 0;
 
     const calls = [];
     const origFill = ctx.fillText;
@@ -1849,7 +1849,7 @@ describe('Score count-up animation', () => {
     game.score         = origScore;
     game.isNewBest     = origNewBest;
     game.highScore     = origHS;
-    game.deathAnimFrame = origAnimFrame;
+    Animations.deathAnimFrame = origAnimFrame;
 
     assert(calls.some(t => t === '00000'),
       `Expected '00000' (score at frame 0), got: ${JSON.stringify(calls)}`);


### PR DESCRIPTION
## Summary

- Removes 7 countdown timer fields from the `game` object (`deathAnimFrame`, `deathShakeFrames`, `deathFlashFrames`, `scorePopFrames`, `milestoneFrames`, `newBestFrames`, `copyFlashFrames`) and consolidates them into an `Animations` object in Section 4
- `Animations.reset()` replaces 7 manual zero-assignments in `resetGame()` — adding a new timer now requires exactly one place instead of two
- `global.Animations` exported in Section 10; all test references updated from `game.X` to `Animations.X`
- `Animations` added to `CONTEXT.md`

## Depth improvement

Before: 7 counters scattered across `game` with no reset contract — `resetGame()` had to enumerate them by hand (easy to forget one, as happened with `copyFlashFrames`). After: one seam. The deletion test passes — removing `Animations` would scatter reset logic back across every handler.

## Test plan

- [ ] CI passes (`node tests/game.test.js`)
- [ ] Death flash, score pop, milestone flash, new best badge tests all pass
- [ ] `resetGame()` correctly zeroes all animation counters

🤖 Generated with [Claude Code](https://claude.com/claude-code)