### PR TITLE
fix: cancel pending rAF before restarting from death

### DIFF
--- a/script.js
+++ b/script.js
@@ -1141,6 +1141,7 @@ function handleAction() {
       game.deathAnimFrame = GAME_CONFIG.DEATH_ANIM_FRAMES;
       drawGameOverScreen();
     } else {
+      cancelAnimationFrame(game.animationFrameId);
       resetGame();
       gameLoop();
     }


### PR DESCRIPTION
## The bug

After dying and pressing space to restart, the game ran noticeably faster for the first few seconds. Root cause: a **duplicate game loop**.

`handleAction()` in the DEAD→restart branch called `resetGame()` then `gameLoop()` — but the dead-state loop was still alive via `requestAnimationFrame`. Two loops then ran concurrently, each scheduling their own rAF, and both fired on every visual frame. That doubled the rate of score increments, speed updates, and obstacle scrolling.

## The fix

One line: add `cancelAnimationFrame(game.animationFrameId)` before `resetGame()`, matching the pattern already used by `setMode()` (line 553) and the daily-mode toggle (line 1273).

## Why only Updated mode was obviously affected

Classic mode's speed is lower and the difference is harder to notice at low scores. Updated mode has visible environmental motion (hills, clouds, particles), making the doubled frame rate immediately perceptible.

## Test plan
- [ ] CI passes
- [ ] Play the game: die, restart — speed at start of new run should match the first run
- [ ] Mode toggle and daily toggle are unaffected (they already cancelled correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)