### PR TITLE
design: add pillars to docs + remove in-run Daily badge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,10 @@ The Node stubs at the top of `script.js` provide just enough of `window`, `docum
 
 To run a single block in the browser, open `tests/test-runner.html` (if present) or load `tests/game.test.js` from devtools. Console output uses ANSI/CSS styling for pass/fail.
 
+### Using `/tdd` in this project
+
+When running `/tdd`, tests must only use globals exported in the `Section 10 — Test exposure` block at the bottom of `script.js` (the `if (typeof process !== 'undefined' ...)` block). Canvas draw calls are no-ops — assert against `game.*` state, not pixels. `ctx.drawImage` and similar can be spied on by reassigning the property and restoring after the test.
+
 ## Deploy pipeline
 
 `.github/workflows/pages.yml`:
@@ -168,6 +172,33 @@ location.reload()
 
 Read the `cfg()` block at the top of `script.js` Section 2 for the full list of safe-to-tune keys (and the explicit "do not tune physics" warning).
 
+## Known invariants
+
+Rules that apply across all call sites. Violating these silently misbehaves rather than crashes — so they must be checked during any refactor that touches the affected code.
+
+**`cancelAnimationFrame` before restarting the loop.** Any code path that calls `resetGame()` + `gameLoop()` must first call `cancelAnimationFrame(game.animationFrameId)`, or a duplicate loop is created and the game runs at double speed. Current compliant sites: `setMode()`, daily-mode toggle, `handleAction()` (DEAD→restart branch). Pattern: `cancelAnimationFrame(game.animationFrameId); resetGame(); gameLoop();`
+
+**`game.rng()` is the only source of gameplay randomness.** Obstacle type, spawn-gap jitter, hill init/respawn all use `game.rng()`. `Math.random()` is reserved for purely cosmetic effects (particles, clouds, audio pitch). Swapping them breaks the daily-challenge determinism contract.
+
+**Physics/spawning/scoring read `GAME_CONFIG.X` directly — never via `cfg()`.** `cfg()` is for visual tunables only. Any physics or spawning value routed through `cfg()` would allow live-tuning overrides to perturb the determinism contract.
+
 ## Where design history lives
 
 `docs/dev/specs/` and `docs/dev/plans/` carry the original design decisions and implementation plans for past phases. Treat these as a historical record — read for context, but don't rewrite or delete them as part of unrelated work.
+
+## Design pillars
+
+Three pillars define what the game is trying to make the player feel. Every new feature must serve at least one — if it doesn't, it doesn't belong.
+
+1. **Flow** — primary emotion. A great run feels like time disappeared. Any feature that snaps the player out of rhythm is a design problem.
+2. **Atmosphere** — deepens flow in Updated mode (hills, clouds, particles, day/night). Must stay peripheral — never drawing the eye away from the obstacle lane. Never added to Classic mode.
+3. **One shared run** — the Daily Challenge. Social context (badge, share result) belongs at the edges of the run only, not during gameplay.
+
+## CONTEXT.md as a live working document
+
+`CONTEXT.md` is the authoritative glossary for domain terms and architectural decisions. During any grilling or planning session:
+
+- **Check it first** before naming a new concept — does a term already exist?
+- **Update it immediately** when a term is resolved or sharpened — don't batch
+- **Add invariants** (see above) when a new one is identified during grilling
+- Future sessions opening `CONTEXT.md` should already know what was decided and why, without having to re-derive it

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,12 +1,32 @@
 # Domain Context — Chrome Offline Rex
 
+## Design Pillars
+
+**Flow** — the primary emotion the game is designed to create. A great run feels like time disappeared: the player stops thinking and just reacts. Every design decision should be evaluated against whether it protects or breaks this rhythm.
+_Avoid_: fun, enjoyment, engagement (too broad)
+
+**Atmosphere** — the peripheral world that deepens the flow state in Updated mode: scrolling hills, clouds, particles, day/night cycle. Atmosphere should be noticed only when the player is already in the zone — never demanding attention or drawing the eye away from the obstacle lane. It is a servant of Flow, not a separate goal.
+_Avoid_: visuals, juice, polish (too generic)
+
+**Classic mode** — the "pure flow" experience: no atmosphere, one obstacle type, nothing between the player and the obstacle. Its minimalism is intentional, not a deficiency. Classic should never receive atmospheric features — doing so would betray its identity. It is not an inferior Updated mode; it is a different answer to the same Flow pillar.
+_Avoid_: stripped-down mode, legacy mode, basic mode
+
+**One shared run** — the third pillar: once per day, every player faces the same obstacle sequence. Gives scores meaning and creates a social moment via the Share Result. The "shared" context belongs at the edges of the run (pre-run framing, post-run result screen) — not during the run, where it induces anxiety and breaks Flow. The in-run Daily badge violates this and should be removed from the HUD.
+_Avoid_: daily mode, social feature, leaderboard
+
+**Restart countdown** — the GET READY countdown shown in the WAITING state before each run. On first run: shown in full (builds anticipation for a new player). On restart after death: skippable by pressing space, so a player already in flow-mindset can return to RUNNING immediately without waiting 4 seconds.
+_Avoid_: grace period, warmup, delay
+
 ## Core Concepts
+
+**Cluster obstacle** — the obstacle type that unlocks at score 250, rendered as two side-by-side cacti. It must be visually distinct from the small and big cacti so a player encountering it for the first time reads "two obstacles" at a glance. An unrecognisable first encounter at score 250+ is a fairness break, not an earned surprise — the player has invested a long run before losing to something confusing.
+_Avoid_: double cactus, pair obstacle, twin obstacle
 
 **DifficultyProfile** — the module that owns the relationship between score and game feel. It defines how fast the game moves at any given score, when obstacles spawn, and what type they are. All tunable numbers live here; the game loop reads from it rather than computing inline.
 
 **Difficulty curve** — how speed and obstacle density scale with score. The curve starts gently, accelerates through the mid-game, and plateaus at a speed the player can sustain with focus. It is continuous (no sudden jumps at level boundaries) and sigmoid-shaped (slow ramp-up, steeper middle, soft plateau).
 
-**Plateau** — the ceiling of the difficulty curve. Chosen to feel "focusable but demanding" — a skilled player can hold this speed indefinitely, but it is not forgiving of lapses in attention.
+**Plateau** — the ceiling of the difficulty curve. Chosen to feel "focusable but demanding" — a skilled player can hold this speed indefinitely, but it is not forgiving of lapses in attention. The plateau is communicated to the player exactly once per run via a light peripheral cue (e.g. a brief particle burst or flash) when they first reach it — never repeated, never prominent enough to break the obstacle lane's focus. The cue reframes failure at high score from "this is impossible" to "I've reached the hard part, now I need to hold it." Atmosphere rules apply: the signal must stay peripheral.
 
 **Level** — a discrete score milestone (every 100 points) used for milestone flash effects and visual feedback only. Speed no longer steps at level boundaries; it increases continuously.
 

--- a/script.js
+++ b/script.js
@@ -787,10 +787,6 @@ function drawScore() {
       GAME_CONFIG.CANVAS_W - GAME_CONFIG.SCORE_X_OFFSET - GAME_CONFIG.SCORE_HI_X_OFFSET - 20,
       GAME_CONFIG.SCORE_Y
     );
-    // Daily badge top-left
-    ctx.font = '13px ' + cfg('SCORE_FONT_FAMILY');
-    ctx.textAlign = 'left';
-    ctx.fillText('📅 DAILY #' + dailyNumber(), 12, GAME_CONFIG.SCORE_Y);
   } else if (game.highScore > 0) {
     ctx.fillText(
       'HI ' + String(game.highScore).padStart(5, '0'),


### PR DESCRIPTION
## Summary

Outcome of a `/grill-with-docs` session on game design pillars.

**Three pillars established and written into CLAUDE.md + CONTEXT.md:**
1. **Flow** — primary emotion. Any feature that snaps the player out of rhythm is a design problem.
2. **Atmosphere** — deepens flow in Updated mode, stays peripheral, never added to Classic.
3. **One shared run** — the Daily Challenge. Social context belongs at the edges of a run, not during gameplay.

**Player-facing change: removed the `📅 DAILY #N` badge from the in-run HUD.**

The badge was shown every frame during a Daily run in the top-left corner. This kept the player aware that the run was "special," inducing loss aversion and anxiety — the opposite of flow. The daily context (badge, daily best, share button) now lives exclusively on the game-over screen where it belongs.

## Test plan
- [ ] CI passes
- [ ] Play a Daily Challenge run — no badge visible during gameplay
- [ ] Game-over screen after a Daily run still shows `📅 DAILY #N`, daily best, and share button
- [ ] Updated and Classic free-play runs unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)