### PR TITLE
design: pillars in CONTEXT.md, remove in-run Daily badge, attach daily-challenge artefacts

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -22,6 +22,33 @@ _Avoid_: grace period, warmup, delay
 **Cluster obstacle** — the obstacle type that unlocks at score 250, rendered as two side-by-side cacti. It must be visually distinct from the small and big cacti so a player encountering it for the first time reads "two obstacles" at a glance. An unrecognisable first encounter at score 250+ is a fairness break, not an earned surprise — the player has invested a long run before losing to something confusing.
 _Avoid_: double cactus, pair obstacle, twin obstacle
 
+**Obstacle** — any on-screen hazard the dino must jump over.
+_Avoid_: enemy, object
+
+**Obstacle type** — the category of a spawned obstacle (e.g. small cactus, cluster cactus).
+_Avoid_: obstacle kind, obstacle variant
+
+**Spawn gap** — the pixel distance between the right edge of the canvas and the trigger point for the next obstacle spawn.
+_Avoid_: gap, spacing, next gap
+
+**Jitter** — a random ±variation applied to the **spawn gap** in updated mode to prevent metronomic spacing. Only applied in updated mode; classic-mode spawn gaps are deterministic.
+_Avoid_: randomness, variation
+
+**Score** — the primary measure of how far a run has progressed; the sole input to the difficulty curve.
+_Avoid_: distance, points
+
+**Speed** — the obstacle scroll speed in pixels per frame at the current score.
+_Avoid_: velocity, game speed, scroll speed
+
+**Initial speed** — the speed at score 0 — the lowest point of the difficulty curve.
+_Avoid_: start speed, base speed
+
+**Ramp midpoint** — the score value where the difficulty curve's rate of change is steepest; the inflection point of the sigmoid.
+_Avoid_: midpoint, acceleration point
+
+**Ramp steepness** — a tuning coefficient that controls how sharply speed rises around the ramp midpoint.
+_Avoid_: slope, sigmoid slope
+
 **DifficultyProfile** — the module that owns the relationship between score and game feel. It defines how fast the game moves at any given score, when obstacles spawn, and what type they are. All tunable numbers live here; the game loop reads from it rather than computing inline.
 
 **Difficulty curve** — how speed and obstacle density scale with score. The curve starts gently, accelerates through the mid-game, and plateaus at a speed the player can sustain with focus. It is continuous (no sudden jumps at level boundaries) and sigmoid-shaped (slow ramp-up, steeper middle, soft plateau).
@@ -33,6 +60,11 @@ _Avoid_: double cactus, pair obstacle, twin obstacle
 **Particles** — the module that owns the particle pool, kind definitions, and all emit/update/draw/reset behaviour. Callers invoke `Particles.emit(kind, x, y)` without knowing pool size, reduced-motion rules, or mode gating — all suppression logic lives inside. Visual-only: uses `Math.random()`, never `game.rng()`.
 
 **Animations** — the module that owns all per-run animation countdown timers (death shake, death flash, score pop, milestone flash, new-best badge, copy flash, death score count-up). A single `Animations.reset()` call zeroes all counters at the start of each run. Handlers and draw functions read and write counters directly via `Animations.X`.
+
+## Randomness
+
+**RNG** — the seeded pseudo-random number generator used for all in-run randomness; shared between obstacle type selection and spawn gap jitter to preserve determinism. Consumed in a fixed order (type first, gap second) per spawn — swapping breaks deterministic replay. `Math.random()` is reserved for cosmetic effects only (particles, clouds, audio pitch).
+_Avoid_: random, rand
 
 ## Daily Challenge
 
@@ -58,3 +90,8 @@ _Avoid_: share score, copy result, clipboard share
 - The **Daily number** is computed from the same date as the **Daily seed** but is display-only — it does not influence the obstacle sequence
 - **Daily best** is independent of all-time best; both are shown on the Game Over screen when in Daily Challenge
 - A **Share result** references both the **Daily number** and the **Daily best**
+
+## Flagged Ambiguities
+
+- **"speed cap"** appears in code as `SPEED_CAP` (kept for the particle-trail threshold) but is distinct from **plateau** — `SPEED_CAP` is a hard ceiling for particle effects, while **plateau** is the soft ceiling the difficulty curve targets. Prefer **plateau** in domain discussion; reserve "speed cap" for talking about the particle threshold specifically.
+- **"gap"** is overloaded: it can mean the on-screen pixel distance between obstacles (a rendering concept) or `nextSpawnGap` (the trigger threshold). Always qualify: **spawn gap** for the game-logic threshold.

--- a/docs/adr/0001-daily-challenge-as-separate-button.md
+++ b/docs/adr/0001-daily-challenge-as-separate-button.md
@@ -1,0 +1,7 @@
+# Daily challenge is a separate button, not a third mode in the Classic/Updated toggle
+
+Daily challenge changes the RNG seed source, not the visual or audio behaviour of the game — it is not a "mode" in the same sense as Classic vs Updated. Adding it to the mode cycle would misrepresent what the toggle does and would prevent playing daily challenge in either visual style. Instead, a dedicated `📅 Daily` button activates it: pressing it locks Updated mode (daily runs require jitter and obstacle variety to be meaningful), hides the Classic/Updated toggle while active, and deactivates on the next free-play run.
+
+## Considered options
+
+**Third mode (Classic → Updated → Daily):** Simpler UI surface — one toggle handles everything. Rejected because daily challenge is orthogonal to visual mode, not a progression of it. It also prevents a future "daily in classic" option if that ever becomes desirable.

--- a/docs/adr/0002-daily-challenge-unlimited-attempts.md
+++ b/docs/adr/0002-daily-challenge-unlimited-attempts.md
@@ -1,0 +1,3 @@
+# Daily challenge allows unlimited attempts per day
+
+The Wordle pattern (one attempt, then locked out) was considered and rejected. Limiting to one attempt adds friction, requires tracking "already played today" in localStorage, and punishes players who die early to a bad RNG gap. The replayability goal is met by tracking a separate daily best — players are pulled back by wanting to beat today's sequence, not by scarcity. Unlimited attempts also sidesteps the "I accidentally hit space" problem that would waste the day's run.

--- a/docs/dev/plans/2026-05-01-daily-challenge.md
+++ b/docs/dev/plans/2026-05-01-daily-challenge.md
@@ -1,0 +1,203 @@
+# Daily Challenge
+
+**Date:** 2026-05-01
+**Status:** Approved
+
+## Goal
+
+Add a daily challenge mode that seeds `game.rng` from the current calendar date, giving all players the same obstacle sequence each day. Replayability hook: players return to beat their daily best. No backend required.
+
+---
+
+## Design decisions
+
+See ADRs:
+- `docs/adr/0001-daily-challenge-as-separate-button.md` — why daily is a button, not a third mode
+- `docs/adr/0002-daily-challenge-unlimited-attempts.md` — why unlimited attempts, not one-and-done
+
+---
+
+## Domain terms
+
+See `CONTEXT.md` — Daily Challenge section. Key terms: **daily seed**, **daily number**, **daily best**, **share result**.
+
+---
+
+## Seed + daily number
+
+```js
+// Daily seed: YYYYMMDD integer — same for every player on the same calendar day
+function dailySeed() {
+  const d = new Date();
+  return d.getFullYear() * 10000 + (d.getMonth() + 1) * 100 + d.getDate();
+}
+
+// Daily number: days since project epoch (Day 1 = 2026-03-01)
+const DAILY_EPOCH_MS = new Date('2026-03-01T00:00:00Z').getTime();
+function dailyNumber() {
+  return Math.floor((Date.now() - DAILY_EPOCH_MS) / 86400000) + 1;
+}
+```
+
+`dailySeed()` replaces `Date.now() & 0xffffffff` as the `mulberry32` seed in `resetGame()` when `isDailyMode()` is true.
+
+---
+
+## localStorage keys (additions)
+
+| Key | Format | Written by | Read by |
+|---|---|---|---|
+| `dino-daily-date` | YYYYMMDD integer string | `saveDailyBest()` | `loadDailyBest()` at boot |
+| `dino-daily-best` | integer string | `saveDailyBest()` | `game.dailyBest` init |
+
+`loadDailyBest()` compares `dino-daily-date` against today's `dailySeed()`. If they differ, the stored best is stale — return 0 and let `resetGame()` start fresh.
+
+---
+
+## MODES change
+
+```js
+const MODES = Object.freeze({ CLASSIC: 'classic', UPDATED: 'updated', DAILY: 'daily' });
+function isDailyMode()   { return game.mode === MODES.DAILY; }
+function isUpdatedMode() { return game.mode === MODES.UPDATED || game.mode === MODES.DAILY; }
+```
+
+`isDailyMode()` is new. `isUpdatedMode()` gains the `|| isDailyMode()` clause so all Updated-mode features (particles, audio, obstacle variety, hills) activate automatically in daily mode.
+
+`MODES.DAILY` is never persisted to `dino-mode` — the daily button is a session-level activation, not a remembered preference.
+
+---
+
+## `game` object additions
+
+```js
+dailyBest:    loadDailyBest(),   // today's best score; 0 if date changed since last visit
+```
+
+---
+
+## `resetGame()` change
+
+```js
+game.rng = isDailyMode()
+  ? mulberry32(dailySeed())
+  : mulberry32(Date.now() & 0xffffffff);
+```
+
+---
+
+## HUD changes (`drawScore()`)
+
+When `isDailyMode()`:
+
+1. **Top-left badge** — render `📅 DAILY #N` in small monospace at `(12, SCORE_Y)`.
+2. **Top-right scores** — replace `HI` label with `TODAY`; show `game.dailyBest` instead of `game.highScore`.
+
+When not in daily mode, `drawScore()` is unchanged.
+
+---
+
+## Game Over screen changes (death handler + `drawDeathScreen()`)
+
+When `isDailyMode()`:
+
+1. Update `game.dailyBest` if current score exceeds it, then call `saveDailyBest()`.
+2. Render `TODAY BEST: XXXXX` line below the score line.
+3. Render a `📋 Copy result` text button below the restart prompt.
+
+`📋 Copy result` is hit-tested in the existing mouse/touch handler. On activation:
+
+```js
+function shareDailyResult() {
+  const text = [
+    `Rex Daily #${dailyNumber()} 🦕`,
+    `Score: ${Math.floor(game.score)}`,
+    `https://snehiths19.github.io/chrome-offline-Rex/`,
+  ].join('\n');
+  if (navigator.clipboard) {
+    navigator.clipboard.writeText(text).catch(() => {});
+  }
+}
+```
+
+No UI feedback needed beyond the button text momentarily changing to `✓ Copied` for ~1.5 s (driven by a `game.copyFlashFrames` counter, similar to existing flash counters).
+
+---
+
+## UI / HTML changes
+
+`index.html`: add `<button id="daily-btn" aria-label="Daily challenge">📅</button>` alongside `#mute-btn`.
+
+When daily mode is active, add class `daily-active` to `#game-wrapper` (or equivalent container). CSS hides the Classic/Updated mode toggle while this class is present:
+
+```css
+.daily-active #mode-btn { display: none; }
+```
+
+When daily mode is deactivated (player presses the daily button again, or navigates away and back), remove the class and restore the toggle.
+
+---
+
+## Files touched
+
+| File | What changes |
+|---|---|
+| `script.js` | MODES, isUpdatedMode, new helpers (dailySeed, dailyNumber, loadDailyBest, saveDailyBest, shareDailyResult), resetGame, drawScore, drawDeathScreen, death handler, input handler, Section 10 test exposure |
+| `index.html` | Add `#daily-btn` |
+| `style.css` | Position `#daily-btn`; `.daily-active #mode-btn { display: none; }` |
+| `tests/game.test.js` | New describe blocks (see below) |
+| `CONTEXT.md` | Daily Challenge section (already written) |
+| `docs/adr/` | Two ADRs (already written) |
+
+---
+
+## Tests
+
+```
+describe('Daily seed')
+  it('dailySeed() returns an 8-digit YYYYMMDD integer')
+  it('dailySeed() is the same when called twice on the same day')
+
+describe('Daily number')
+  it('dailyNumber() returns a positive integer')
+  it('dailyNumber() is greater for a later date')
+
+describe('Daily best persistence')
+  it('loadDailyBest() returns 0 when stored date does not match today')
+  it('loadDailyBest() returns stored value when date matches today')
+  it('saveDailyBest() stores score and today date; subsequent loadDailyBest returns it')
+
+describe('Share result')
+  it('shareDailyResult() returns a string containing the daily number and score')
+  it('shareDailyResult() does not throw when navigator.clipboard is unavailable')
+
+describe('Daily mode RNG seeding')
+  it('resetGame() in daily mode seeds rng from dailySeed(), not Date.now()')
+  it('two resets in daily mode produce the same obstacle type sequence')
+```
+
+---
+
+## Implementation phases
+
+1. **Seed + daily number utilities + tests** — `dailySeed()`, `dailyNumber()`, `loadDailyBest()`, `saveDailyBest()`. No visible change. (~45 min)
+2. **MODES + resetGame hook** — add `MODES.DAILY`, update `isUpdatedMode()`, wire `resetGame()`. Tests for deterministic replay. (~30 min)
+3. **Daily button + mode-toggle hide** — HTML + CSS + input handler. Daily mode now activatable. (~30 min)
+4. **HUD badge + TODAY label** — update `drawScore()`. (~20 min)
+5. **Death screen: daily best + share button** — update death handler + `drawDeathScreen()` + `shareDailyResult()`. (~45 min)
+6. **Polish pass** — copyFlash feedback, button active state, test on mobile. (~30 min)
+
+Total: ~3.5 hours.
+
+---
+
+## Verification checklist
+
+- [ ] Same date produces the same obstacle sequence across two browser tabs
+- [ ] Daily best persists across page reloads on the same day
+- [ ] Daily best resets to 0 on the next day (verify by temporarily overriding `dailySeed()` return value)
+- [ ] Classic/Updated toggle is hidden while daily mode is active; restored when deactivated
+- [ ] Share button copies correctly formatted text to clipboard
+- [ ] Share button shows `✓ Copied` feedback for ~1.5 s
+- [ ] `npm test` — all existing tests + ~8 new tests pass
+- [ ] With OS reduce-motion on: particles suppressed, audio unchanged, HUD badge visible


### PR DESCRIPTION
## Summary

- Add design pillars (Flow / Atmosphere / Classic / One-shared-run / Restart countdown) to `CONTEXT.md` and remove the in-run Daily badge from the HUD (already in commit `76ca0bd`).
- Reconcile the parallel `UBIQUITOUS_LANGUAGE.md` glossary into `CONTEXT.md` and delete the source file. Adds 9 missing terms (`Score`, `Speed`, `Initial speed`, `Ramp midpoint`, `Ramp steepness`, `Obstacle`, `Obstacle type`, `Spawn gap`, `Jitter`, `RNG`) plus a `Flagged Ambiguities` section. `CONTEXT.md` is now the single authoritative glossary, per `CLAUDE.md`.
- Attach the two daily-challenge ADRs (`docs/adr/0001-daily-challenge-as-separate-button.md`, `docs/adr/0002-daily-challenge-unlimited-attempts.md`) as the historical record for PR #37's design decisions.
- Attach the daily-challenge implementation plan (`docs/dev/plans/2026-05-01-daily-challenge.md`) as historical record per `CLAUDE.md`'s `docs/dev/plans/` policy.

## Test plan

- [ ] CI green (`npm test` + `npm run lint` on push)
- [ ] `CONTEXT.md` reads end-to-end without duplicate or contradictory term definitions
- [ ] `UBIQUITOUS_LANGUAGE.md` no longer present in repo root
- [ ] Two ADR files present under `docs/adr/`
- [ ] Daily-challenge plan present under `docs/dev/plans/`

## Out of scope

- Implementing the **plateau cue** described in `CONTEXT.md` (separate session)
- Implementing the **skippable restart countdown** described in `CONTEXT.md` (separate session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)