### PR TITLE
Feel parity with chrome://dino: fixed-timestep loop + official tuning, gap & scoring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,7 @@ const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matc
 | `dino-tuning` | JSON | `saveTuning()` | `loadTuning()` at boot |
 | `dino-daily-date` | YYYYMMDD integer string | `ScoreStore.saveDailyBest()` | `ScoreStore.loadDailyBest()` |
 | `dino-daily-best` | integer string | `ScoreStore.saveDailyBest()` | `ScoreStore.loadDailyBest()` |
+| `dino-score-scale` | `'v2'` | `migrateScoreScale()` | `migrateScoreScale()` at boot |
 
 ## Test harness
 
@@ -175,6 +176,10 @@ Read the `cfg()` block at the top of `script.js` Section 2 for the full list of 
 ## Known invariants
 
 Rules that apply across all call sites. Violating these silently misbehaves rather than crashes — so they must be checked during any refactor that touches the affected code.
+
+**Fixed-timestep loop.** `gameLoop(now)` accumulates real elapsed time and steps `STATE_HANDLERS` in fixed `MS_PER_STEP` (1/60 s) chunks, so the game runs at a true 60 Hz on any refresh rate. A **no-arg `gameLoop()` call advances exactly one step** — tests and the kickoff/restart sites depend on this. `loopAccumulator`/`loopLastTime` reset in `resetGame()`; bogus (NaN/backward/>250 ms) deltas collapse to a single step.
+
+**Score scale is v2 (distance-based).** `game.score = game.distance × DISTANCE_COEFFICIENT`; `game.distance` accumulates `game.currentSpeed` per step. `migrateScoreScale()` clears pre-v2 stored scores once at load, guarded by the `dino-score-scale` key.
 
 **`cancelAnimationFrame` before restarting the loop.** Any code path that calls `resetGame()` + `gameLoop()` must first call `cancelAnimationFrame(game.animationFrameId)`, or a duplicate loop is created and the game runs at double speed. Current compliant sites: `setMode()`, daily-mode toggle, `handleAction()` (DEAD→restart branch). Pattern: `cancelAnimationFrame(game.animationFrameId); resetGame(); gameLoop();`
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,26 +34,20 @@ _Avoid_: gap, spacing, next gap
 **Jitter** — a random ±variation applied to the **spawn gap** in updated mode to prevent metronomic spacing. Only applied in updated mode; classic-mode spawn gaps are deterministic.
 _Avoid_: randomness, variation
 
-**Score** — the primary measure of how far a run has progressed; the sole input to the difficulty curve.
+**Score** — the primary measure of how far a run has progressed; the sole input to the difficulty curve. Computed as `game.distance × DISTANCE_COEFFICIENT` (v2 scale), where `game.distance` accumulates `game.currentSpeed` each fixed step. `migrateScoreScale()` clears any pre-v2 stored scores on first boot after the upgrade.
 _Avoid_: distance, points
 
-**Speed** — the obstacle scroll speed in pixels per frame at the current score.
+**Speed** — the obstacle scroll speed in pixels per fixed step (1/60 s). Increases linearly by `ACCELERATION` per step from `INITIAL_SPEED`, capped at `SPEED_CAP`.
 _Avoid_: velocity, game speed, scroll speed
 
-**Initial speed** — the speed at score 0 — the lowest point of the difficulty curve.
+**Initial speed** — the speed at the start of a run — the lowest point of the difficulty curve (value: `INITIAL_SPEED`).
 _Avoid_: start speed, base speed
-
-**Ramp midpoint** — the score value where the difficulty curve's rate of change is steepest; the inflection point of the sigmoid.
-_Avoid_: midpoint, acceleration point
-
-**Ramp steepness** — a tuning coefficient that controls how sharply speed rises around the ramp midpoint.
-_Avoid_: slope, sigmoid slope
 
 **DifficultyProfile** — the module that owns the relationship between score and game feel. It defines how fast the game moves at any given score, when obstacles spawn, and what type they are. All tunable numbers live here; the game loop reads from it rather than computing inline.
 
-**Difficulty curve** — how speed and obstacle density scale with score. The curve starts gently, accelerates through the mid-game, and plateaus at a speed the player can sustain with focus. It is continuous (no sudden jumps at level boundaries) and sigmoid-shaped (slow ramp-up, steeper middle, soft plateau).
+**Difficulty curve** — how speed and obstacle density scale with score. Speed increases linearly from `INITIAL_SPEED` by `ACCELERATION` each fixed step (1/60 s), capping at `SPEED_CAP`. Obstacle density follows the official gap model: `spawn gap = round(obstacleWidth × speed + minGap × GAP_COEFFICIENT)`, randomised up to `MAX_GAP_COEFFICIENT`. The curve is continuous (no sudden jumps at level boundaries).
 
-**Plateau** — the ceiling of the difficulty curve. Chosen to feel "focusable but demanding" — a skilled player can hold this speed indefinitely, but it is not forgiving of lapses in attention. The plateau is communicated to the player exactly once per run via a light peripheral cue (e.g. a brief particle burst or flash) when they first reach it — never repeated, never prominent enough to break the obstacle lane's focus. The cue reframes failure at high score from "this is impossible" to "I've reached the hard part, now I need to hold it." Atmosphere rules apply: the signal must stay peripheral.
+**Plateau** — the ceiling of the difficulty curve, reached when `game.currentSpeed` hits `SPEED_CAP`. Chosen to feel "focusable but demanding" — a skilled player can hold this speed indefinitely, but it is not forgiving of lapses in attention. The plateau is communicated to the player exactly once per run via a light peripheral cue (e.g. a brief particle burst or flash) when they first reach it — never repeated, never prominent enough to break the obstacle lane's focus. The cue reframes failure at high score from "this is impossible" to "I've reached the hard part, now I need to hold it." Atmosphere rules apply: the signal must stay peripheral.
 
 **Level** — a discrete score milestone (every 100 points) used for milestone flash effects and visual feedback only. Speed no longer steps at level boundaries; it increases continuously.
 
@@ -93,5 +87,5 @@ _Avoid_: share score, copy result, clipboard share
 
 ## Flagged Ambiguities
 
-- **"speed cap"** appears in code as `SPEED_CAP` (kept for the particle-trail threshold) but is distinct from **plateau** — `SPEED_CAP` is a hard ceiling for particle effects, while **plateau** is the soft ceiling the difficulty curve targets. Prefer **plateau** in domain discussion; reserve "speed cap" for talking about the particle threshold specifically.
+- **"speed cap"** (`SPEED_CAP`) is the single hard ceiling for `game.currentSpeed`. It also doubles as the particle-trail threshold (trail activates at 85 % of `SPEED_CAP`). **Plateau** is the domain-level name for this ceiling — prefer **plateau** in design discussions; use "speed cap" only when referring to the code constant.
 - **"gap"** is overloaded: it can mean the on-screen pixel distance between obstacles (a rendering concept) or `nextSpawnGap` (the trigger threshold). Always qualify: **spawn gap** for the game-logic threshold.

--- a/docs/superpowers/plans/2026-05-25-official-feel-parity.md
+++ b/docs/superpowers/plans/2026-05-25-official-feel-parity.md
@@ -1,0 +1,688 @@
+# Official Chrome Dino Feel-Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the existing dino game *move* like the official `chrome://dino` — framerate-independent timing plus official tuning (gravity, jump, speed, gap, scoring). Feel parity only; no duck/birds/sprite work.
+
+**Architecture:** A fixed-timestep accumulator drives the existing `STATE_HANDLERS` once per 1/60 s step (fixing the 144 Hz → 2.4× speed bug) while a no-arg single-step path keeps the current test suite driving frames unchanged. Tuning, gap, and scoring then move to the official model. Daily-challenge determinism is preserved because the seeded RNG call order is unchanged and a run executes the same number of fixed steps at any refresh rate.
+
+**Tech Stack:** Vanilla JS, single `script.js`, custom Node test harness (`tests/game.test.js`), no bundler. Spec: `docs/superpowers/specs/2026-05-25-official-feel-parity-design.md`.
+
+**Verification gates (run after every task):**
+- `npm test` — full suite under Node, must be green.
+- `npm run lint` — ESLint, must be clean.
+
+**Determinism rules (do not violate):** physics/spawning/scoring read `GAME_CONFIG.X` directly (never `cfg()`). `game.rng()` is the only gameplay randomness; preserve the call order **type-pick first, gap-roll second** inside `nextObstacle`.
+
+---
+
+## Task 1: Framerate-independent fixed-timestep loop
+
+Replaces the per-rAF stepping with a time accumulator. After this task the game runs at a true 60 Hz on any monitor; tuning is still the old values.
+
+**Files:**
+- Modify: `script.js` — `gameLoop()` (≈ line 1515), `resetGame()` (≈ line 1309), add module vars just above `gameLoop`.
+- Test: `tests/game.test.js` — append a new `describe('Fixed-timestep loop', …)` block at end of file (before the final EOF).
+
+- [ ] **Step 1: Write the failing determinism test**
+
+Append to `tests/game.test.js`:
+
+```js
+describe('Fixed-timestep loop', () => {
+  const MS = 1000 / 60;
+
+  // Drive the loop with explicit timestamps and report how many physics
+  // steps (game.animFrame ticks) ran over the timeline.
+  function runTimeline(frameCount, deltaPerFrame) {
+    resetGame();
+    game.graceFrames = 0;
+    game.state = STATE.RUNNING;
+    game.rng = mulberry32(2024);      // pin RNG so both timelines spawn identically
+    const startAnim = game.animFrame;
+    let t = 1000;
+    gameLoop(t);                       // baseline frame — establishes lastTime, runs 0 steps
+    cancelAnimationFrame(game.animationFrameId);
+    for (let i = 0; i < frameCount; i++) {
+      t += deltaPerFrame;
+      gameLoop(t);
+      cancelAnimationFrame(game.animationFrameId);
+    }
+    return game.animFrame - startAnim;
+  }
+
+  it('runs the same number of physics steps per wall-clock second regardless of refresh rate', () => {
+    const steps60  = runTimeline(60,  MS);        // 60 frames * 16.67ms ≈ 1000ms
+    const steps144 = runTimeline(144, MS / 2.4);  // 144 frames * 6.94ms ≈ 1000ms
+    assert(steps60 >= 58 && steps60 <= 62,   `60Hz: expected ~60 steps, got ${steps60}`);
+    assert(steps144 >= 58 && steps144 <= 62, `144Hz: expected ~60 steps (not ~144), got ${steps144}`);
+    assert(Math.abs(steps60 - steps144) <= 2, `step counts must match across refresh rates: 60Hz=${steps60}, 144Hz=${steps144}`);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test, verify it FAILS**
+
+Run: `npm test`
+Expected: FAIL — current `gameLoop` ignores its argument and runs one handler per call, so the 144-call timeline produces ~144 steps, tripping `steps144 <= 62` and the `<= 2` difference assertion.
+
+- [ ] **Step 3: Implement the accumulator loop**
+
+In `script.js`, just above `function gameLoop()` (≈ line 1515), add module state:
+
+```js
+// Fixed-timestep clock. Physics advances in MS_PER_STEP chunks so the game runs
+// at a true 60 Hz on any refresh rate. lastTime/accumulator reset in resetGame().
+const MS_PER_STEP = 1000 / 60;
+const MAX_CATCHUP_STEPS = 5;
+let loopLastTime;            // undefined until the first timestamped frame
+let loopAccumulator = 0;
+```
+
+Replace the whole `gameLoop` function:
+
+```js
+function gameLoop(now) {
+  game.animationFrameId = requestAnimationFrame(gameLoop);
+
+  // No-arg call = advance exactly one fixed step. Used by tests and by the
+  // kickoff/restart sites before the browser starts supplying timestamps.
+  if (now === undefined) {
+    STATE_HANDLERS[game.state]();
+    return;
+  }
+
+  if (loopLastTime === undefined) loopLastTime = now;   // first timestamped frame: 0 delta
+  let frame = now - loopLastTime;
+  loopLastTime = now;
+  if (frame > 250) frame = MS_PER_STEP;                 // backgrounded tab — don't fast-forward
+  loopAccumulator += frame;
+
+  let steps = 0;
+  while (loopAccumulator >= MS_PER_STEP && steps < MAX_CATCHUP_STEPS) {
+    STATE_HANDLERS[game.state]();
+    loopAccumulator -= MS_PER_STEP;
+    steps++;
+  }
+  if (steps === MAX_CATCHUP_STEPS) loopAccumulator = 0; // sustained-slowness clamp
+}
+```
+
+In `resetGame()`, add the clock reset right after `dino.isJumping = false;` (≈ line 1312):
+
+```js
+  loopAccumulator = 0;
+  loopLastTime = undefined;
+```
+
+- [ ] **Step 4: Run the test, verify it PASSES**
+
+Run: `npm test`
+Expected: the new determinism test PASSES, and **all existing tests still pass** (they call `gameLoop()` with no argument → single-step path → identical behaviour to before).
+
+- [ ] **Step 5: Add clamp guard tests, verify PASS**
+
+Append inside the same `describe('Fixed-timestep loop', …)` block:
+
+```js
+  it('clamps catch-up to MAX_CATCHUP_STEPS on sustained slow frames', () => {
+    resetGame(); game.graceFrames = 0; game.state = STATE.RUNNING; game.rng = mulberry32(1);
+    const start = game.animFrame;
+    let t = 1000; gameLoop(t); cancelAnimationFrame(game.animationFrameId);   // baseline
+    t += 100;     gameLoop(t); cancelAnimationFrame(game.animationFrameId);   // 100ms → 6 wanted, clamp 5
+    assert(game.animFrame - start <= 5, `catch-up must clamp to 5 steps, got ${game.animFrame - start}`);
+  });
+
+  it('treats a backgrounded-tab gap as a single step', () => {
+    resetGame(); game.graceFrames = 0; game.state = STATE.RUNNING; game.rng = mulberry32(1);
+    const start = game.animFrame;
+    let t = 1000; gameLoop(t);  cancelAnimationFrame(game.animationFrameId);  // baseline
+    t += 5000;    gameLoop(t);  cancelAnimationFrame(game.animationFrameId);  // 5s gap → frame>250 → 1 step
+    assertEquals(game.animFrame - start, 1, 'a >250ms frame should advance exactly one step');
+  });
+```
+
+Run: `npm test` — Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add script.js tests/game.test.js
+git commit -m "feat: framerate-independent fixed-timestep game loop"
+```
+
+---
+
+## Task 2: Jump & gravity tuning (kill the float)
+
+**Files:**
+- Modify: `script.js` — `GAME_CONFIG.GRAVITY`, `GAME_CONFIG.JUMP_POWER` (≈ lines 78-79).
+- Test: `tests/game.test.js` — `describe('Dinosaur Jump')` peak-height test (≈ lines 116-134).
+
+- [ ] **Step 1: Update the peak-height test to the new expected value**
+
+The new arc (v₀ = −10, g = 0.6) peaks at ≈ 78px (discrete integration), versus ≈ 144px today. Replace lines 116-134:
+
+```js
+  it('should have a peak jump height of ~78px', () => {
+    // jumpPower=-10, gravity=0.6 → discrete peak ≈ 78px (official-feel snappy arc)
+    resetGame();
+    game.state = STATE.RUNNING;
+    const expectedPeak = 78;
+    jump();
+    let minY = dino.y;
+    const groundY = GAME_CONFIG.CANVAS_H - dino.height;
+    for (let i = 0; i < 60; i++) {
+      dino.velocityY += dino.gravity;
+      dino.y += dino.velocityY;
+      if (dino.y < minY) minY = dino.y;
+      if (dino.y >= groundY) { dino.y = groundY; dino.isJumping = false; break; }
+    }
+    const actualPeak = groundY - minY;
+    assert(Math.abs(actualPeak - expectedPeak) <= 5,
+      `Peak height ${actualPeak.toFixed(1)}px should be ~${expectedPeak}px. ` +
+      `If this passes before changing constants, the test is wrong — rewrite it.`);
+  });
+```
+
+- [ ] **Step 2: Run the test, verify it FAILS**
+
+Run: `npm test`
+Expected: FAIL — with the current gravity 0.48 / jumpPower −12 the peak is ≈ 144px, far outside `78 ± 5`.
+
+- [ ] **Step 3: Apply the official tuning**
+
+In `script.js` `GAME_CONFIG`, change two lines:
+
+```js
+  JUMP_POWER:              -10,   // negative = upward impulse applied on jump (official)
+  GRAVITY:                  0.6,  // added to velocityY each frame while airborne (official)
+```
+
+- [ ] **Step 4: Run the test, verify it PASSES**
+
+Run: `npm test`
+Expected: the peak-height test PASSES (≈ 78px); the other Dinosaur Jump tests (jump up/down, ignore-when-not-running) still pass — they don't assert exact heights.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add script.js tests/game.test.js
+git commit -m "feat: official jump tuning (gravity 0.6, jump velocity -10)"
+```
+
+---
+
+## Task 3: Official obstacle-gap model
+
+Replaces the shrink-with-speed fixed-pixel gap with the official `width × speed + minGap × 0.6`, randomized up to ×1.5. Gap now depends on the chosen obstacle's width/minGap, so `nextObstacle` computes type first, then gap.
+
+**Files:**
+- Modify: `script.js` — `GAME_CONFIG` (add `GAP_COEFFICIENT`, `MAX_GAP_COEFFICIENT`, per-type `minGap`; remove `MAX_SPAWN_GAP`, `MIN_SPAWN_GAP`, `SPAWN_GAP_SPEED_FACTOR`, `SPAWN_GAP_JITTER`), `game.nextSpawnGap` default (≈ line 521), `computeNextSpawnGap` (≈ line 444), `DifficultyProfile.nextObstacle` (≈ line 477), its call site in `handleRunning` (≈ line 1442), and `resetGame` gap init (≈ line 1334).
+- Test: `tests/game.test.js` — `describe('Obstacle Gap Enforcement')` (225-260), `describe('Spawn Gap Jitter')` (262-303), and the gap-related `it`s inside `describe('DifficultyProfile')` (1587-1625).
+
+- [ ] **Step 1: Rewrite the gap tests to the official formula**
+
+Replace `describe('Obstacle Gap Enforcement', …)` (lines 225-260) with:
+
+```js
+describe('Obstacle Gap Enforcement', () => {
+  it('does not spawn a second obstacle until the official gap threshold is met', () => {
+    resetGame();
+    game.graceFrames = 0;
+    game.state = STATE.RUNNING;
+    game.rng = () => 0.5;                 // mid-range gap roll, deterministic
+    game.currentSpeed = GAME_CONFIG.INITIAL_SPEED;
+    game.nextSpawnGap = 100;             // small threshold so frame 1 spawns
+
+    gameLoop(); cancelAnimationFrame(game.animationFrameId);
+    assertEquals(game.obstacles.length, 1, 'first obstacle spawns on frame 1');
+
+    // Recomputed gap must sit within the official band for the spawned type at this speed.
+    const type   = game.obstacles[0].type ? GAME_CONFIG.OBSTACLE_TYPES.find(t => t.id === game.obstacles[0].type) : GAME_CONFIG.OBSTACLE_TYPES[0];
+    const minGap = Math.round(type.width * game.currentSpeed + type.minGap * GAME_CONFIG.GAP_COEFFICIENT);
+    const maxGap = Math.round(minGap * GAME_CONFIG.MAX_GAP_COEFFICIENT);
+    assert(game.nextSpawnGap >= minGap && game.nextSpawnGap <= maxGap,
+      `recomputed gap ${game.nextSpawnGap} must be in [${minGap}, ${maxGap}]`);
+
+    gameLoop(); cancelAnimationFrame(game.animationFrameId);
+    assertEquals(game.obstacles.length, 1, 'no new obstacle until gap distance elapses');
+
+    game.obstacles[0].x = GAME_CONFIG.CANVAS_W - (game.nextSpawnGap + 1);
+    game.lastObstacleX  = game.obstacles[0].x;
+    gameLoop(); cancelAnimationFrame(game.animationFrameId);
+    assertEquals(game.obstacles.length, 2, 'second obstacle spawns once gap threshold met');
+  });
+});
+```
+
+> Note: if `spawnObstacle` does not record the type id on the obstacle, the `find(...)` falls back to the small cactus — the band still bounds the value. Do not add a `.type` field to obstacles just for this test (the Difficulty Curve test asserts obstacles carry no extra props).
+
+Replace `describe('Spawn Gap Jitter', …)` (lines 262-303) with:
+
+```js
+describe('Spawn Gap (official model)', () => {
+  function band(type, speed) {
+    const minGap = Math.round(type.width * speed + type.minGap * GAME_CONFIG.GAP_COEFFICIENT);
+    return { minGap, maxGap: Math.round(minGap * GAME_CONFIG.MAX_GAP_COEFFICIENT) };
+  }
+
+  it('gap stays within [minGap, minGap*MAX_GAP_COEFFICIENT] for the chosen type', () => {
+    const speed = 8;
+    const rng = mulberry32(12345);
+    for (let i = 0; i < 500; i++) {
+      const { type, gap } = DifficultyProfile.nextObstacle(300, MODES.UPDATED, rng, speed);
+      const { minGap, maxGap } = band(type, speed);
+      assert(gap >= minGap && gap <= maxGap,
+        `gap ${gap} for type ${type.id} at speed ${speed} must be in [${minGap}, ${maxGap}]`);
+    }
+  });
+
+  it('gap grows with speed (official: width*speed dominates)', () => {
+    const rng = () => 0.5;  // fixed mid roll isolates the speed term
+    const slow = DifficultyProfile.nextObstacle(0, MODES.CLASSIC, rng, 6);
+    const fast = DifficultyProfile.nextObstacle(0, MODES.CLASSIC, rng, 13);
+    assert(fast.gap > slow.gap,
+      `gap at speed 13 (${fast.gap}) should exceed gap at speed 6 (${slow.gap})`);
+  });
+
+  it('produces gap variety across spawns (breaks the metronome)', () => {
+    const rng = mulberry32(7);
+    const gaps = new Set();
+    for (let i = 0; i < 50; i++) gaps.add(DifficultyProfile.nextObstacle(100, MODES.UPDATED, rng, 8).gap);
+    assert(gaps.size >= 5, `expected gap variety; got ${gaps.size} distinct values`);
+  });
+
+  it('mulberry32 is deterministic given same seed', () => {
+    const a = mulberry32(42), b = mulberry32(42);
+    for (let i = 0; i < 10; i++) assertEquals(a(), b(), 'same seed → same sequence');
+  });
+});
+```
+
+Inside `describe('DifficultyProfile', …)`, replace the gap-related `it`s (lines 1587-1625) with:
+
+```js
+  it('nextObstacle returns a numeric gap and a typed obstacle', () => {
+    const rng = mulberry32(42);
+    const params = DifficultyProfile.nextObstacle(0, MODES.CLASSIC, rng, 6);
+    assert(typeof params.gap === 'number', 'gap must be a number');
+    assert(params.type && typeof params.type.id === 'string', 'type must have an id string');
+  });
+
+  it('nextObstacle classic mode: gap grows as speed rises', () => {
+    const rng = () => 0.5;
+    const low  = DifficultyProfile.nextObstacle(0, MODES.CLASSIC, rng, 6);
+    const high = DifficultyProfile.nextObstacle(0, MODES.CLASSIC, rng, 13);
+    assert(high.gap > low.gap, `gap at speed 13 (${high.gap}) should exceed speed 6 (${low.gap})`);
+  });
+
+  it('nextObstacle classic mode: type is always small cactus', () => {
+    const rng = mulberry32(42);
+    const params = DifficultyProfile.nextObstacle(500, MODES.CLASSIC, rng, 10);
+    assertEquals(params.type.id, 'small', 'classic mode always returns the small cactus');
+  });
+
+  it('nextObstacle updated mode: gap within official band at low speed', () => {
+    const rng = mulberry32(42);
+    const speed = 6;
+    const params = DifficultyProfile.nextObstacle(0, MODES.UPDATED, rng, speed);
+    const minGap = Math.round(params.type.width * speed + params.type.minGap * GAME_CONFIG.GAP_COEFFICIENT);
+    const maxGap = Math.round(minGap * GAME_CONFIG.MAX_GAP_COEFFICIENT);
+    assert(params.gap >= minGap && params.gap <= maxGap,
+      `gap ${params.gap} must be in [${minGap}, ${maxGap}]`);
+  });
+
+  it('nextObstacle updated mode: cluster cactus returned at score 250 with max roll', () => {
+    const rng = () => 0.99;  // type pick (call 1) → last eligible; gap roll (call 2) → top of band
+    const params = DifficultyProfile.nextObstacle(250, MODES.UPDATED, rng, 8);
+    assertEquals(params.type.id, 'cluster', 'at score 250 with max roll, cluster wins the weighted draw');
+  });
+```
+
+- [ ] **Step 2: Run the tests, verify they FAIL**
+
+Run: `npm test`
+Expected: FAIL — `GAP_COEFFICIENT` / `MAX_GAP_COEFFICIENT` / per-type `minGap` are undefined and `nextObstacle` ignores the new `speed` argument, so the band math is `NaN`/wrong.
+
+- [ ] **Step 3: Add the new config, remove the old gap config**
+
+In `GAME_CONFIG`, replace the `--- Spawning ---` block (lines 95-100) with:
+
+```js
+  // --- Spawning (official gap model) ---
+  GRACE_FRAMES:           240,    // ~4 s at 60 fps before first obstacle appears
+  GAP_COEFFICIENT:          0.6,  // official: minGap = width*speed + typeMinGap*GAP_COEFFICIENT
+  MAX_GAP_COEFFICIENT:      1.5,  // official: gap randomized up to minGap * this
+```
+
+Add a `minGap` to each entry in `OBSTACLE_TYPES` (lines 110-114):
+
+```js
+  OBSTACLE_TYPES: Object.freeze([
+    Object.freeze({ id: 'small',   width: 20, height: 40, unlockScore:   0, weight: 50, render: 'single', minGap: 120 }),
+    Object.freeze({ id: 'big',     width: 30, height: 55, unlockScore: 100, weight: 30, render: 'single', minGap: 120 }),
+    Object.freeze({ id: 'cluster', width: 50, height: 40, unlockScore: 250, weight: 20, render: 'double', minGap: 150 }),
+  ]),
+```
+
+Change the `game.nextSpawnGap` default (line 521) — `MAX_SPAWN_GAP` is gone:
+
+```js
+  nextSpawnGap:     0,            // set by resetGame() via computeNextSpawnGap
+```
+
+- [ ] **Step 4: Rewrite `computeNextSpawnGap` and `nextObstacle`**
+
+Replace `computeNextSpawnGap` (lines 444-453) with:
+
+```js
+// Official gap model: gap scales with the chosen obstacle's width and the current
+// speed, randomized within [minGap, minGap*MAX_GAP_COEFFICIENT]. The rng() draw is
+// the second seeded call per spawn (type pick is first) — order is load-bearing
+// for the daily-challenge determinism contract.
+function computeNextSpawnGap(rng, speed, type) {
+  const minGap = Math.round(type.width * speed + type.minGap * GAME_CONFIG.GAP_COEFFICIENT);
+  const maxGap = Math.round(minGap * GAME_CONFIG.MAX_GAP_COEFFICIENT);
+  return minGap + Math.floor(rng() * (maxGap - minGap + 1));
+}
+```
+
+Replace `DifficultyProfile.nextObstacle` (lines 477-486) with a version that takes the current speed and passes the chosen type into the gap calc:
+
+```js
+  nextObstacle(score, mode, rng, speed) {
+    // RNG call order is load-bearing: type roll first, gap roll second.
+    const type = pickObstacleType(rng, score, mode);
+    return {
+      type,
+      gap: computeNextSpawnGap(rng, speed, type),
+    };
+  },
+```
+
+> `DifficultyProfile.speedAtScore` is still present and untouched here — Task 4 removes it.
+
+- [ ] **Step 5: Update the two call sites**
+
+In `handleRunning` (line 1442), pass the current speed:
+
+```js
+    const params = DifficultyProfile.nextObstacle(game.score, game.mode, game.rng, game.currentSpeed);
+```
+
+In `resetGame` (line 1334), compute the initial gap from the small cactus at the starting speed (no longer via `speedAtScore`):
+
+```js
+  game.nextSpawnGap = computeNextSpawnGap(game.rng, game.currentSpeed, GAME_CONFIG.OBSTACLE_TYPES[0]);
+```
+
+- [ ] **Step 6: Run the tests, verify they PASS**
+
+Run: `npm test`
+Expected: all gap tests PASS. If any other test references a removed key (`MAX_SPAWN_GAP`, `MIN_SPAWN_GAP`, `SPAWN_GAP_SPEED_FACTOR`, `SPAWN_GAP_JITTER`), grep and fix it — only the blocks rewritten above should reference them.
+
+- [ ] **Step 7: Lint + commit**
+
+```bash
+npm run lint
+git add script.js tests/game.test.js
+git commit -m "feat: official obstacle-gap model (width*speed + minGap*0.6)"
+```
+
+---
+
+## Task 4: Linear speed model
+
+Replaces the sigmoid `speedAtScore` with the official linear acceleration: start at 6, add 0.001 per step, cap at `SPEED_CAP` (13).
+
+**Files:**
+- Modify: `script.js` — `GAME_CONFIG` (`INITIAL_SPEED` → 6, add `ACCELERATION`, remove `PLATEAU_SPEED`/`RAMP_MIDPOINT`/`RAMP_STEEPNESS`), remove `DifficultyProfile.speedAtScore` (≈ 472-476), the speed assignment in `handleRunning` (≈ 1404), and the speed-trail gate that referenced `PLATEAU_SPEED` (≈ 1434).
+- Test: `tests/game.test.js` — `describe('Difficulty Curve')` (751-773) and the `speedAtScore` `it`s in `describe('DifficultyProfile')` (1553-1585).
+
+- [ ] **Step 1: Rewrite the speed tests**
+
+Replace the first `it` in `describe('Difficulty Curve', …)` (lines 752-765) with:
+
+```js
+  it('currentSpeed accelerates by ACCELERATION each step and caps at SPEED_CAP', () => {
+    resetGame(); game.state = STATE.RUNNING; game.graceFrames = 0;
+    const s0 = game.currentSpeed;
+    assertEquals(s0, GAME_CONFIG.INITIAL_SPEED, 'run starts at INITIAL_SPEED');
+
+    gameLoop(); cancelAnimationFrame(game.animationFrameId);
+    game.obstacles.length = 0;   // keep the dino alive for the rest of the checks
+    assert(Math.abs(game.currentSpeed - (s0 + GAME_CONFIG.ACCELERATION)) < 1e-9,
+      `one step should add ACCELERATION; got ${game.currentSpeed} from ${s0}`);
+
+    game.currentSpeed = GAME_CONFIG.SPEED_CAP - GAME_CONFIG.ACCELERATION / 2;
+    game.obstacles.length = 0;
+    gameLoop(); cancelAnimationFrame(game.animationFrameId);
+    assertEquals(game.currentSpeed, GAME_CONFIG.SPEED_CAP, 'speed clamps at SPEED_CAP');
+  });
+```
+
+Delete the four `speedAtScore` `it`s in `describe('DifficultyProfile', …)` (lines 1553-1585: "midpoint speed", "slightly above INITIAL_SPEED", "never exceeds PLATEAU_SPEED", "monotonically increasing"). They test a function that no longer exists.
+
+- [ ] **Step 2: Run the tests, verify they FAIL**
+
+Run: `npm test`
+Expected: FAIL — `ACCELERATION` is undefined (`NaN` comparison) and the old midpoint test still expects sigmoid behaviour.
+
+- [ ] **Step 3: Update config — linear speed, remove sigmoid keys**
+
+In `GAME_CONFIG` replace the physics speed lines (80-84) with:
+
+```js
+  INITIAL_SPEED:            6.0,  // obstacle scroll speed at run start (official)
+  SPEED_CAP:               13.0,  // max scroll speed (official MAX_SPEED)
+  ACCELERATION:             0.001, // linear speed gain per fixed step (official)
+```
+
+(Delete `PLATEAU_SPEED`, `RAMP_MIDPOINT`, `RAMP_STEEPNESS`.)
+
+- [ ] **Step 4: Replace the speed function with accumulation**
+
+Delete `DifficultyProfile.speedAtScore` (lines 472-476). The object becomes just `nextObstacle`:
+
+```js
+const DifficultyProfile = {
+  nextObstacle(score, mode, rng, speed) {
+    const type = pickObstacleType(rng, score, mode);
+    return { type, gap: computeNextSpawnGap(rng, speed, type) };
+  },
+};
+```
+
+In `handleRunning`, replace the speed assignment (line 1404):
+
+```js
+  game.currentSpeed = Math.min(game.currentSpeed + GAME_CONFIG.ACCELERATION, GAME_CONFIG.SPEED_CAP);
+```
+
+Replace the speed-trail gate that referenced `PLATEAU_SPEED` (line 1434) with a fraction of the cap:
+
+```js
+  if (isUpdatedMode() && game.currentSpeed >= GAME_CONFIG.SPEED_CAP * 0.85) {
+```
+
+`resetGame` already sets `game.currentSpeed = GAME_CONFIG.INITIAL_SPEED` (line 1321) — no change needed; it now starts at 6.
+
+- [ ] **Step 5: Run the tests, verify they PASS**
+
+Run: `npm test`
+Expected: PASS. Grep for any remaining `speedAtScore` / `PLATEAU_SPEED` / `RAMP_` references and remove them — there should be none outside what this task changed.
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+npm run lint
+git add script.js tests/game.test.js
+git commit -m "feat: official linear speed ramp (start 6, +0.001/step, cap 13)"
+```
+
+---
+
+## Task 5: Distance-based scoring + high-score migration
+
+Switches scoring from `+0.1/frame` to the official distance × 0.025 (accelerating climb), and clears the now-incompatible stored high score exactly once.
+
+**Files:**
+- Modify: `script.js` — `GAME_CONFIG` (add `DISTANCE_COEFFICIENT`, remove `SCORE_INCREMENT`), add `game.distance` field (≈ line 524) and reset it (≈ resetGame line 1318), the scoring line in `handleRunning` (≈ line 1400), add `migrateScoreScale()` near `ScoreStore` (≈ line 231), and expose it (Section 10).
+- Test: `tests/game.test.js` — extend `describe('Scoring')` (207-223).
+
+- [ ] **Step 1: Write the failing scoring + migration tests**
+
+Add two `it`s inside `describe('Scoring', …)` (after line 222, before the closing `});`):
+
+```js
+  it('score equals accumulated distance times DISTANCE_COEFFICIENT', () => {
+    resetGame();
+    game.state = STATE.RUNNING;
+    game.graceFrames = 0;
+    for (let i = 0; i < 10; i++) { gameLoop(); cancelAnimationFrame(game.animationFrameId); }
+    assert(Math.abs(game.score - game.distance * GAME_CONFIG.DISTANCE_COEFFICIENT) < 1e-9,
+      `score ${game.score} must equal distance ${game.distance} * ${GAME_CONFIG.DISTANCE_COEFFICIENT}`);
+    assert(game.score > 0, 'score should have advanced over 10 steps');
+  });
+
+  it('migrateScoreScale clears pre-v2 scores exactly once', () => {
+    localStorage.setItem('dino-high-score', '9999');
+    localStorage.setItem('dino-daily-best', '4242');
+    localStorage.removeItem('dino-score-scale');
+    migrateScoreScale();
+    assertEquals(localStorage.getItem('dino-high-score'), null, 'pre-v2 high score cleared');
+    assertEquals(localStorage.getItem('dino-daily-best'), null, 'pre-v2 daily best cleared');
+    assertEquals(localStorage.getItem('dino-score-scale'), 'v2', 'scale marked v2');
+    // second run is a no-op
+    localStorage.setItem('dino-high-score', '50');
+    migrateScoreScale();
+    assertEquals(localStorage.getItem('dino-high-score'), '50', 'already-migrated: no further clearing');
+  });
+```
+
+- [ ] **Step 2: Run the tests, verify they FAIL**
+
+Run: `npm test`
+Expected: FAIL — `DISTANCE_COEFFICIENT` undefined (so `game.score` uses old `SCORE_INCREMENT` and the equality is false) and `migrateScoreScale` is not defined.
+
+- [ ] **Step 3: Add config, distance state, and the migration function**
+
+In `GAME_CONFIG`, replace the `SCORE_INCREMENT` line (86):
+
+```js
+  DISTANCE_COEFFICIENT:     0.025, // official: score = distance * this (accelerating climb)
+```
+
+Add a `distance` field to the `game` object, right after `score: 0,` (line 524):
+
+```js
+  distance:         0,
+```
+
+Add the migration function immediately after the `ScoreStore` object (after line 231):
+
+```js
+// One-time score-scale migration. v2 switched to distance-based scoring, so
+// pre-v2 high scores live on an incompatible scale — clear them once, guarded by
+// a version key so it never repeats.
+function migrateScoreScale() {
+  if (localStorage.getItem('dino-score-scale') === 'v2') return;
+  localStorage.removeItem('dino-high-score');
+  localStorage.removeItem('dino-daily-best');
+  localStorage.removeItem('dino-daily-date');
+  localStorage.setItem('dino-score-scale', 'v2');
+}
+migrateScoreScale();
+```
+
+> Placement matters: this must run **before** `game.highScore = ScoreStore.loadHighScore()` (line 525) so the boot read sees the cleared value.
+
+- [ ] **Step 4: Switch `handleRunning` to distance-based scoring**
+
+Replace the score line (1400) — accumulate distance using the current speed, then derive score (keep `game.animFrame++` on the next line):
+
+```js
+  game.distance += game.currentSpeed;
+  game.score = game.distance * GAME_CONFIG.DISTANCE_COEFFICIENT;
+```
+
+In `resetGame`, reset distance next to `game.score = 0;` (line 1318):
+
+```js
+  game.distance = 0;
+```
+
+- [ ] **Step 5: Expose `migrateScoreScale` to tests**
+
+In Section 10 (the `if (typeof process …)` block, ≈ line 1581 near `global.ScoreStore`), add:
+
+```js
+  global.migrateScoreScale = migrateScoreScale;
+```
+
+- [ ] **Step 6: Run the tests, verify they PASS**
+
+Run: `npm test`
+Expected: PASS — including the pre-existing `describe('Scoring')` "increment" test (distance still grows the score) and the `describe('High Score')` block (saves/loads still work on the new scale).
+
+- [ ] **Step 7: Lint + commit**
+
+```bash
+npm run lint
+git add script.js tests/game.test.js
+git commit -m "feat: distance-based scoring + one-time high-score scale migration"
+```
+
+---
+
+## Task 6: Full verification, docs, and manual feel check
+
+**Files:**
+- Modify: `script.js` Section 2 comment header if it still lists removed keys; `CONTEXT.md` and `CLAUDE.md` (record the new invariants).
+- No test file changes expected unless the full run surfaces a straggler.
+
+- [ ] **Step 1: Full green gate**
+
+Run: `npm test`
+Expected: entire suite PASS.
+Run: `npm run lint`
+Expected: clean.
+
+- [ ] **Step 2: Grep for orphaned references to removed keys**
+
+Run: `git grep -nE "SCORE_INCREMENT|MAX_SPAWN_GAP|MIN_SPAWN_GAP|SPAWN_GAP_SPEED_FACTOR|SPAWN_GAP_JITTER|PLATEAU_SPEED|RAMP_MIDPOINT|RAMP_STEEPNESS|speedAtScore" -- script.js tests/`
+Expected: no output. If anything remains, fix it (likely a comment) and re-run the green gate.
+
+- [ ] **Step 3: Record the new invariants in CONTEXT.md / CLAUDE.md**
+
+Add to the "Known invariants" section of `CLAUDE.md`:
+- **Fixed-timestep loop.** `gameLoop(now)` accumulates real time and steps `STATE_HANDLERS` in fixed `MS_PER_STEP` (1/60 s) chunks. A **no-arg `gameLoop()` call advances exactly one step** — tests and the kickoff/restart sites rely on this. `loopAccumulator`/`loopLastTime` reset in `resetGame()`.
+- **Score scale is v2 (distance-based).** `score = distance × DISTANCE_COEFFICIENT`. `migrateScoreScale()` clears pre-v2 stored scores once, guarded by the `dino-score-scale` key.
+
+Update the `localStorage` keys table in `CLAUDE.md` to add `dino-score-scale` (`'v2'`, written by `migrateScoreScale()`).
+
+- [ ] **Step 4: Manual feel check in the browser**
+
+Run: `npm run serve`
+Open `http://localhost:8080`. Confirm by feel against `chrome://dino` (open side by side):
+- Jump is a lower, snappier "pop" — no float/hang.
+- Game starts at a brisk pace (not slow) and accelerates smoothly.
+- Obstacle spacing feels official; spacing widens as speed climbs.
+- On this 144 Hz monitor the game no longer runs ~2.4× too fast.
+- High score started fresh (one-time reset) and climbs at a believable rate.
+
+- [ ] **Step 5: Commit docs**
+
+```bash
+git add CLAUDE.md CONTEXT.md script.js
+git commit -m "docs: record fixed-timestep + distance-scoring invariants"
+```
+
+---
+
+## Self-review notes (author)
+
+- **Spec coverage:** §1 fixed-timestep → Task 1; §2 tuning (gravity/jump) → Task 2, (speed) → Task 4; §3 gap → Task 3, scoring → Task 5; high-score migration → Task 5; testing strategy → tests in every task; out-of-scope items (duck/birds/multi-box/sprite) → not implemented, as intended. The optional `velocity − speed/10` jump-distance touch from the spec is **deliberately dropped** (YAGNI: it complicates the jump tests and the user's complaint was float + gaps, not high-speed jump distance); revisit later if desired.
+- **Type/name consistency:** module vars `MS_PER_STEP`, `MAX_CATCHUP_STEPS`, `loopLastTime`, `loopAccumulator`; config keys `ACCELERATION`, `GAP_COEFFICIENT`, `MAX_GAP_COEFFICIENT`, `DISTANCE_COEFFICIENT`, per-type `minGap`; `nextObstacle(score, mode, rng, speed)`; `migrateScoreScale()` — used identically across tasks.
+- **Determinism:** RNG order (type then gap) preserved in `nextObstacle`; fixed steps keep step-count framerate-independent; no physics value routed through `cfg()`.

--- a/docs/superpowers/specs/2026-05-25-official-feel-parity-design.md
+++ b/docs/superpowers/specs/2026-05-25-official-feel-parity-design.md
@@ -1,0 +1,223 @@
+# Official Chrome Dino — Feel Parity Pass
+
+- **Date:** 2026-05-25
+- **Status:** Approved (design); pending spec review before planning
+- **Scope owner:** Snehith
+- **Topic slug:** official-feel-parity
+
+## Problem
+
+The game "plays different" from the official `chrome://dino`. Investigation found
+**three independent causes**, two of which the player consciously feels (floaty
+jump, wrong obstacle spacing) and one they feel without isolating (everything too
+fast):
+
+1. **Frame-based physics on a 144 Hz display.** `gameLoop()` (script.js:1515) steps
+   physics once per rendered frame with no time delta, e.g. `dino.velocityY +=
+   dino.gravity; dino.y += dino.velocityY` (script.js:1482-1483). This is correct
+   only at 60 Hz. The dev machine runs at **144 Hz**, so the whole game — motion
+   *and* score — runs at **144 / 60 = 2.4×** the official speed in wall-clock time.
+   The official scales every step by `deltaTime / (1000/60)` and is therefore
+   identical at any refresh rate.
+
+2. **Floaty jump tuning.** `GRAVITY 0.48` (vs official `0.6`) makes the dino fall
+   slowly and hang at the apex; `JUMP_POWER -12` (vs official `-10`) launches it
+   higher. Together: a tall, slow, floaty arc. The official is a lower, snappier
+   "pop." Note this is independent of refresh rate — the arc *shape* is identical
+   at any FPS; only the tuning controls float.
+
+3. **Inverted gap model.** Current spawn gap *shrinks* with speed
+   (`MAX_SPAWN_GAP 600` shrinking by `SPAWN_GAP_SPEED_FACTOR 50` per +1 speed,
+   computeNextSpawnGap at script.js:444). The official gap *grows* with speed via
+   `width × speed + minGap × 0.6`. This is the "gaps feel off" complaint.
+
+## Goal
+
+Make the existing game **move like the official** — feel parity only. The same
+game, retuned and re-clocked so that what happens on screen matches `chrome://dino`.
+
+## Non-goals (explicitly out of scope)
+
+- Ducking / fast-fall (down arrow `SPEED_DROP`).
+- Pterodactyl (bird) obstacles.
+- Multi-box collision (official approximates each sprite with several boxes; we
+  keep the single padded hitbox).
+- Sprite-accuracy / asset parity.
+
+These are deferred. This pass is purely about how the game *moves*.
+
+## Official baseline reference
+
+Verified against the faithful mirror `github.com/wayou/t-rex-runner` (`index.js`),
+a clean extraction of Chromium's `components/neterror/resources/offline.js`.
+
+| Constant | Official value |
+|---|---|
+| `SPEED` (start) | 6 |
+| `MAX_SPEED` | 13 |
+| `ACCELERATION` | 0.001 / frame (linear) |
+| `GRAVITY` | 0.6 |
+| `INITIAL_JUMP_VELOCITY` | -10 (Trex), scaled `- speed/10` at launch |
+| `GAP_COEFFICIENT` | 0.6 |
+| `MAX_GAP_COEFFICIENT` | 1.5 |
+| obstacle `minGap` | cactus 120, pterodactyl 150 |
+| distance coefficient | 0.025 |
+| `FPS` / `msPerFrame` | 60 / 16.67 ms |
+
+## Design
+
+Three changes, all confined to the loop, `GAME_CONFIG`, and the spawn/score logic.
+Modes (classic / updated / daily), juice, atmosphere, day/night, audio, HUD, idle
+screen, and mobile scaling are untouched.
+
+### 1. Fixed-timestep loop (Section 8)
+
+Decision: **fixed-timestep accumulator** (chosen over deltaTime-scaling and
+60 fps-cap). It fixes the 2.4× speed bug, keeps the physics code stepping by fixed
+amounts (minimal change), preserves the daily-challenge determinism contract, and
+still renders at full 144 Hz.
+
+Replace the loop:
+
+```js
+const MS_PER_STEP = 1000 / 60;
+let lastTime = performance.now(), accumulator = 0;
+
+function gameLoop(now) {
+  game.animationFrameId = requestAnimationFrame(gameLoop);
+  let frame = now - lastTime; lastTime = now;
+  if (frame > 250) frame = MS_PER_STEP;        // tab was backgrounded — don't fast-forward
+  accumulator += frame;
+  let steps = 0;
+  while (accumulator >= MS_PER_STEP && steps++ < 5) {  // clamp 5 = no spiral-of-death
+    STATE_UPDATE[game.state]();                // physics / state mutation only
+    accumulator -= MS_PER_STEP;
+  }
+  STATE_DRAW[game.state]();                     // render exactly once per rAF
+}
+```
+
+This requires splitting each state handler (`handleIdle`, `handleWaiting`,
+`handleRunning`, `handleDead`) into an **update** half and a **draw** half. Today
+they interleave physics and drawing (e.g. `handleRunning` mutates state then draws
+at script.js:1501-1505).
+
+Beneficial side effect: all frame-counted animations (death shake, score pop,
+milestone, idle bob) currently run 2.4× too fast at 144 Hz. Because a "step" is now
+a true 1/60 s, they self-correct with no per-counter changes.
+
+**Determinism:** a run executes the same number of fixed steps at 60 or 144 Hz, so
+seeded-RNG draws (obstacle type, gap jitter, hill respawn) occur in the same order
+and the daily challenge stays reproducible. The `cancelAnimationFrame` invariant
+(CLAUDE.md) is unchanged.
+
+### 2. Tuning — official numbers (`GAME_CONFIG`, Section 2)
+
+| Key | Current | New |
+|---|---|---|
+| `GRAVITY` | 0.48 | **0.6** |
+| `JUMP_POWER` | -12 | **-10** |
+| `INITIAL_SPEED` | 3.0 | **6** |
+| acceleration model | sigmoid | **linear**, `+0.001`/step, cap `SPEED_CAP 13` |
+
+`dino.gravity` / `dino.jumpPower` already read from config (script.js:331-332), so
+those propagate automatically.
+
+**Speed model change.** Today speed is a pure function of score:
+`DifficultyProfile.speedAtScore()` (sigmoid, script.js:473-475), reassigned every
+frame (script.js:1404). Replace with **accumulation**:
+
+```js
+game.currentSpeed = Math.min(game.currentSpeed + ACCELERATION, SPEED_CAP);
+```
+
+per fixed step, starting at `INITIAL_SPEED`. Retire `PLATEAU_SPEED`,
+`RAMP_MIDPOINT`, `RAMP_STEEPNESS`, and `speedAtScore()`. Call sites that read
+`speedAtScore(score)` (e.g. `nextObstacle`, resetGame at script.js:1334) read
+`game.currentSpeed` instead. Day/night is unaffected — it keys off **score** at
+300 (`DAY_NIGHT_START`), not speed.
+
+Optional fidelity touch (one line, easy to drop): at launch, scale jump velocity by
+speed — `dino.velocityY = dino.jumpPower - game.currentSpeed / 10` — so jump
+*distance* stays roughly constant as speed climbs. Included by default.
+
+### 3. Gap model + scoring
+
+**Gap** (`computeNextSpawnGap`, script.js:444). Replace shrink-with-speed model
+with the official:
+
+```js
+const minGap = Math.round(typeWidth * speed + typeMinGap * GAP_COEFFICIENT); // 0.6
+const maxGap = Math.round(minGap * MAX_GAP_COEFFICIENT);                      // 1.5
+gap = minGap + Math.floor(rng() * (maxGap - minGap + 1));   // rng = game.rng — determinism preserved
+```
+
+Add per-type `minGap` to `OBSTACLE_TYPES` (small/big 120, cluster 150) and config
+keys `GAP_COEFFICIENT 0.6`, `MAX_GAP_COEFFICIENT 1.5`. Retire `MAX_SPAWN_GAP`,
+`MIN_SPAWN_GAP`, `SPAWN_GAP_SPEED_FACTOR`. Keep `SPAWN_GAP_JITTER`? No — the
+official's `rand(minGap, minGap×1.5)` already supplies the jitter; remove the
+separate jitter term to avoid double-randomizing.
+
+**Scoring** (`game.score += SCORE_INCREMENT`, script.js:1400). Replace frame-count
+scoring with distance-based, matching the official's accelerating climb:
+
+```js
+game.distance += game.currentSpeed;          // per fixed step
+game.score = game.distance * DISTANCE_COEFFICIENT;   // 0.025
+```
+
+Add `DISTANCE_COEFFICIENT 0.025`; retire `SCORE_INCREMENT`. Milestone/`SCORE_PER_LEVEL`
+logic keys off `Math.floor(score)` and is unaffected.
+
+## High-score migration
+
+Distance-based scoring is a different numeric scale than the old frame-based score,
+so stored `dino-high-score` (and `dino-daily-best`) are no longer comparable. On
+first load of the new version, **clear the stored best once**, guarded by a version
+key in localStorage so it happens exactly once:
+
+```js
+if (localStorage.getItem('dino-score-scale') !== 'v2') {
+  localStorage.removeItem('dino-high-score');
+  localStorage.removeItem('dino-daily-best');
+  localStorage.setItem('dino-score-scale', 'v2');
+}
+```
+
+*(Alternative, if vetoed at review: keep frame-based scoring entirely. Fixed-timestep
+already fixes the 2.4× inflation, so the score-too-fast problem is solved either
+way — distance scoring is purely for matching the official's accelerating climb.)*
+
+## Testing strategy
+
+Tests assert against `game.*` state, not pixels (CLAUDE.md test harness).
+
+- **Update** existing assertions whose numbers change: jump apex height (new
+  gravity/velocity), spawn-gap expectations, score progression.
+- **Add:**
+  - *Fixed-step determinism:* driving the loop with variable frame times produces
+    identical `game.*` state after N simulated seconds as a clean 60 Hz run.
+  - *Gap formula:* `computeNextSpawnGap` output matches `width×speed + minGap×0.6`
+    bounds for representative speeds.
+  - *Distance scoring:* `score == distance × 0.025`.
+  - *Speed ramp:* `currentSpeed` rises linearly from 6, caps at 13.
+  - *Daily determinism preserved:* same seed → same obstacle sequence after all
+    changes.
+- `npm test` and `npm run lint` must pass (CI + Pages deploy gates).
+
+## Risks
+
+- **Loop refactor (update/draw split)** is the largest change; could disturb
+  death/idle animation timing. Mitigation: the split is mechanical, and the new
+  fixed-step clock makes frame-counted animations *more* correct, not less.
+- **Spiral-of-death** on a stalled/backgrounded tab. Mitigation: `frame > 250`
+  reset and `steps < 5` clamp.
+- **High-score reset** is user-visible. Mitigation: one-time, version-guarded;
+  documented above.
+
+## Resolved decisions
+
+1. Fidelity: feel parity only (no duck / birds / sprite work).
+2. Engine fix: fixed-timestep accumulator.
+3. Speed ramp: exact official (linear from 6, retire sigmoid).
+4. Scoring: distance-based with one-time high-score clear (vetoable at review).

--- a/docs/superpowers/specs/2026-05-25-official-feel-parity-design.md
+++ b/docs/superpowers/specs/2026-05-25-official-feel-parity-design.md
@@ -73,34 +73,47 @@ screen, and mobile scaling are untouched.
 ### 1. Fixed-timestep loop (Section 8)
 
 Decision: **fixed-timestep accumulator** (chosen over deltaTime-scaling and
-60 fps-cap). It fixes the 2.4× speed bug, keeps the physics code stepping by fixed
-amounts (minimal change), preserves the daily-challenge determinism contract, and
-still renders at full 144 Hz.
+60 fps-cap). It fixes the 2.4× speed bug, keeps the existing combined state
+handlers stepping by fixed amounts (minimal change), and preserves the
+daily-challenge determinism contract.
 
-Replace the loop:
+The accumulator drives the **existing** `STATE_HANDLERS[state]()` once per fixed
+1/60 s step — no handler split. Drawing happens inside the handler as today; on a
+144 Hz display most frames run 1 step (≈ every 2.4 rAF callbacks) and the rest run
+0 (the canvas simply retains the last image), so the game updates and renders at a
+true 60 Hz — exactly like the official. (Splitting update from draw to render at
+144 Hz would only redraw identical frames without render interpolation, which is
+out of scope; revisit later if true 144 Hz smoothness is wanted.)
 
 ```js
-const MS_PER_STEP = 1000 / 60;
-let lastTime = performance.now(), accumulator = 0;
+const MS_PER_STEP = 1000 / 60, MAX_STEPS = 5;
+let lastTime, accumulator = 0;          // reset in resetGame()
 
 function gameLoop(now) {
   game.animationFrameId = requestAnimationFrame(gameLoop);
+  if (now === undefined) {              // no-arg: single fixed step (tests + kickoff)
+    STATE_HANDLERS[game.state]();
+    return;
+  }
+  if (lastTime === undefined) lastTime = now;     // first timestamped frame: 0 delta
   let frame = now - lastTime; lastTime = now;
-  if (frame > 250) frame = MS_PER_STEP;        // tab was backgrounded — don't fast-forward
+  if (frame > 250) frame = MS_PER_STEP;           // tab was backgrounded — don't fast-forward
   accumulator += frame;
   let steps = 0;
-  while (accumulator >= MS_PER_STEP && steps++ < 5) {  // clamp 5 = no spiral-of-death
-    STATE_UPDATE[game.state]();                // physics / state mutation only
+  while (accumulator >= MS_PER_STEP && steps < MAX_STEPS) {
+    STATE_HANDLERS[game.state]();
     accumulator -= MS_PER_STEP;
+    steps++;
   }
-  STATE_DRAW[game.state]();                     // render exactly once per rAF
+  if (steps === MAX_STEPS) accumulator = 0;        // spiral-of-death clamp
 }
 ```
 
-This requires splitting each state handler (`handleIdle`, `handleWaiting`,
-`handleRunning`, `handleDead`) into an **update** half and a **draw** half. Today
-they interleave physics and drawing (e.g. `handleRunning` mutates state then draws
-at script.js:1501-1505).
+The **no-arg single-step path** is load-bearing: tests call `gameLoop()` (no
+timestamp) to advance exactly one frame, and the browser/init kickoff calls it the
+same way before rAF takes over with timestamps. This keeps the existing test suite
+driving the game unchanged — only assertions whose numbers change from retuning
+need editing.
 
 Beneficial side effect: all frame-counted animations (death shake, score pop,
 milestone, idle bob) currently run 2.4× too fast at 144 Hz. Because a "step" is now
@@ -207,9 +220,9 @@ Tests assert against `game.*` state, not pixels (CLAUDE.md test harness).
 
 ## Risks
 
-- **Loop refactor (update/draw split)** is the largest change; could disturb
-  death/idle animation timing. Mitigation: the split is mechanical, and the new
-  fixed-step clock makes frame-counted animations *more* correct, not less.
+- **Loop change** could disturb how tests drive frames. Mitigation: the no-arg
+  single-step path preserves the exact `gameLoop()` semantics tests rely on, so the
+  driving mechanism is unchanged; only retuned-number assertions move.
 - **Spiral-of-death** on a stalled/backgrounded tab. Mitigation: `frame > 250`
   reset and `steps < 5` clamp.
 - **High-score reset** is user-visible. Mitigation: one-time, version-guarded;

--- a/script.js
+++ b/script.js
@@ -231,11 +231,13 @@ const ScoreStore = {
 // pre-v2 high scores live on an incompatible scale — clear them once, guarded by
 // a version key so it never repeats.
 function migrateScoreScale() {
-  if (localStorage.getItem('dino-score-scale') === 'v2') return;
-  localStorage.removeItem('dino-high-score');
-  localStorage.removeItem('dino-daily-best');
-  localStorage.removeItem('dino-daily-date');
-  localStorage.setItem('dino-score-scale', 'v2');
+  try {
+    if (localStorage.getItem('dino-score-scale') === 'v2') return;
+    localStorage.removeItem('dino-high-score');
+    localStorage.removeItem('dino-daily-best');
+    localStorage.removeItem('dino-daily-date');
+    localStorage.setItem('dino-score-scale', 'v2');
+  } catch (e) { /* storage unavailable — skip migration */ }
 }
 migrateScoreScale();
 

--- a/script.js
+++ b/script.js
@@ -1530,11 +1530,12 @@ function gameLoop(now) {
     STATE_HANDLERS[game.state]();
     return;
   }
+  if (!Number.isFinite(now)) return;                  // ignore bogus timestamps; keep the clock clean
 
-  if (loopLastTime === undefined) loopLastTime = now;   // first timestamped frame: 0 delta
+  if (loopLastTime === undefined) loopLastTime = now; // first timestamped frame: 0 delta
   let frame = now - loopLastTime;
   loopLastTime = now;
-  if (frame > 250) frame = MS_PER_STEP;                 // backgrounded tab — don't fast-forward
+  if (frame < 0 || frame > 250) frame = MS_PER_STEP;  // clock jumped (backward, or backgrounded tab) — take one step
   loopAccumulator += frame;
 
   let steps = 0;
@@ -1610,4 +1611,6 @@ if (typeof process !== 'undefined' && process.versions && process.versions.node)
   global.ScoreStore = ScoreStore;
   global.isDailyMode = isDailyMode;
   global.shareDailyResult = shareDailyResult;
+  global.MS_PER_STEP = MS_PER_STEP;
+  global.MAX_CATCHUP_STEPS = MAX_CATCHUP_STEPS;
 }

--- a/script.js
+++ b/script.js
@@ -1310,6 +1310,8 @@ function resetGame() {
   dino.y = GAME_CONFIG.CANVAS_H - dino.height;
   dino.velocityY = 0;
   dino.isJumping = false;
+  loopAccumulator = 0;
+  loopLastTime = undefined;
 
   Particles.reset();
 
@@ -1512,9 +1514,36 @@ const STATE_HANDLERS = {
   [STATE.DEAD]:    handleDead,
 };
 
-function gameLoop() {
+// Fixed-timestep clock. Physics advances in MS_PER_STEP chunks so the game runs
+// at a true 60 Hz on any refresh rate. lastTime/accumulator reset in resetGame().
+const MS_PER_STEP = 1000 / 60;
+const MAX_CATCHUP_STEPS = 5;
+let loopLastTime;            // undefined until the first timestamped frame
+let loopAccumulator = 0;
+
+function gameLoop(now) {
   game.animationFrameId = requestAnimationFrame(gameLoop);
-  STATE_HANDLERS[game.state]();
+
+  // No-arg call = advance exactly one fixed step. Used by tests and by the
+  // kickoff/restart sites before the browser starts supplying timestamps.
+  if (now === undefined) {
+    STATE_HANDLERS[game.state]();
+    return;
+  }
+
+  if (loopLastTime === undefined) loopLastTime = now;   // first timestamped frame: 0 delta
+  let frame = now - loopLastTime;
+  loopLastTime = now;
+  if (frame > 250) frame = MS_PER_STEP;                 // backgrounded tab — don't fast-forward
+  loopAccumulator += frame;
+
+  let steps = 0;
+  while (loopAccumulator >= MS_PER_STEP && steps < MAX_CATCHUP_STEPS) {
+    STATE_HANDLERS[game.state]();
+    loopAccumulator -= MS_PER_STEP;
+    steps++;
+  }
+  if (steps === MAX_CATCHUP_STEPS) loopAccumulator = 0; // sustained-slowness clamp
 }
 
 // == SECTION 9: INITIALISATION ==

--- a/script.js
+++ b/script.js
@@ -77,11 +77,9 @@ const GAME_CONFIG = Object.freeze({
   // --- Physics ---
   JUMP_POWER:              -10,   // negative = upward impulse applied on jump (official)
   GRAVITY:                  0.6,  // added to velocityY each frame while airborne (official)
-  INITIAL_SPEED:            3.0,  // obstacle scroll speed at score 0
-  SPEED_CAP:               13.0,  // max scroll speed (matches Chrome T-Rex)
-  PLATEAU_SPEED:            8.0,  // sigmoid ceiling — focusable-but-demanding speed the curve approaches
-  RAMP_MIDPOINT:          300,    // score where acceleration is steepest (day/night transition)
-  RAMP_STEEPNESS:           0.01, // sigmoid slope — controls how quickly speed rises through the midpoint
+  INITIAL_SPEED:            6.0,  // obstacle scroll speed at run start (official)
+  SPEED_CAP:               13.0,  // max scroll speed (official MAX_SPEED)
+  ACCELERATION:             0.001, // linear speed gain per fixed step (official)
   SCORE_PER_LEVEL:        100,    // score points per level — used for milestone flash effects only
   SCORE_INCREMENT:          0.1,  // score added per frame while RUNNING
 
@@ -463,11 +461,6 @@ function pickObstacleType(rng, score, mode) {
 }
 
 const DifficultyProfile = {
-  speedAtScore(score) {
-    const { INITIAL_SPEED, PLATEAU_SPEED, RAMP_STEEPNESS, RAMP_MIDPOINT } = GAME_CONFIG;
-    return INITIAL_SPEED + (PLATEAU_SPEED - INITIAL_SPEED) *
-      (1 / (1 + Math.exp(-RAMP_STEEPNESS * (score - RAMP_MIDPOINT))));
-  },
   nextObstacle(score, mode, rng, speed) {
     // RNG call order is load-bearing: type roll first, gap roll second.
     const type = pickObstacleType(rng, score, mode);
@@ -1395,7 +1388,7 @@ function handleRunning() {
   game.animFrame++;
 
   const level = Math.floor(game.score / GAME_CONFIG.SCORE_PER_LEVEL);
-  game.currentSpeed = DifficultyProfile.speedAtScore(game.score);
+  game.currentSpeed = Math.min(game.currentSpeed + GAME_CONFIG.ACCELERATION, GAME_CONFIG.SPEED_CAP);
 
   // Milestone flash on level-up.
   if (level > prevLevel && level > 0) {
@@ -1425,7 +1418,7 @@ function handleRunning() {
   updateObstacles();
 
   // Speed-trail particles: subtle dust trailing off the dino approaching plateau speed.
-  if (isUpdatedMode() && game.currentSpeed >= GAME_CONFIG.PLATEAU_SPEED * 0.96) {
+  if (isUpdatedMode() && game.currentSpeed >= GAME_CONFIG.SPEED_CAP * 0.85) {
     Particles.emit('trail', dino.x + 4, dino.y + dino.height - 4);
   }
 

--- a/script.js
+++ b/script.js
@@ -105,6 +105,7 @@ const GAME_CONFIG = Object.freeze({
   // Each type unlocks at a score threshold and contributes its `weight` to the
   // weighted random pick once unlocked. `render` controls how drawObstacles()
   // paints it from the single cactus sprite.
+  // `minGap` is the per-type floor fed into the official gap formula (width*speed + minGap*GAP_COEFFICIENT).
   OBSTACLE_TYPES: Object.freeze([
     Object.freeze({ id: 'small',   width: 20, height: 40, unlockScore:   0, weight: 50, render: 'single', minGap: 120 }),
     Object.freeze({ id: 'big',     width: 30, height: 55, unlockScore: 100, weight: 30, render: 'single', minGap: 120 }),

--- a/script.js
+++ b/script.js
@@ -81,7 +81,7 @@ const GAME_CONFIG = Object.freeze({
   SPEED_CAP:               13.0,  // max scroll speed (official MAX_SPEED)
   ACCELERATION:             0.001, // linear speed gain per fixed step (official)
   SCORE_PER_LEVEL:        100,    // score points per level — used for milestone flash effects only
-  SCORE_INCREMENT:          0.1,  // score added per frame while RUNNING
+  DISTANCE_COEFFICIENT:     0.025, // official: score = distance * this (accelerating climb)
 
   // --- Hitbox forgiveness (rendering uses full sprite; collision uses shrunken box) ---
   DINO_PAD_X:               8,
@@ -226,6 +226,18 @@ const ScoreStore = {
     }
   },
 };
+
+// One-time score-scale migration. v2 switched to distance-based scoring, so
+// pre-v2 high scores live on an incompatible scale — clear them once, guarded by
+// a version key so it never repeats.
+function migrateScoreScale() {
+  if (localStorage.getItem('dino-score-scale') === 'v2') return;
+  localStorage.removeItem('dino-high-score');
+  localStorage.removeItem('dino-daily-best');
+  localStorage.removeItem('dino-daily-date');
+  localStorage.setItem('dino-score-scale', 'v2');
+}
+migrateScoreScale();
 
 const STATE = Object.freeze({
   LOADING: 'LOADING',
@@ -507,6 +519,7 @@ const game = {
   graceFrames:      GAME_CONFIG.GRACE_FRAMES,
   animationFrameId: undefined,
   score:            0,
+  distance:         0,
   highScore:        ScoreStore.loadHighScore(),
   animFrame:        0,
   groundX:          0,
@@ -1303,6 +1316,7 @@ function resetGame() {
   game.obstacles.length = 0;
   game.stars.length = 0;
   game.score = 0;
+  game.distance = 0;
   game.animFrame = 0;
   game.groundX = 0;
   game.currentSpeed = GAME_CONFIG.INITIAL_SPEED;
@@ -1384,7 +1398,8 @@ function handleWaiting() {
 
 function handleRunning() {
   const prevLevel = Math.floor(game.score / GAME_CONFIG.SCORE_PER_LEVEL);
-  game.score += GAME_CONFIG.SCORE_INCREMENT;
+  game.distance += game.currentSpeed;
+  game.score = game.distance * GAME_CONFIG.DISTANCE_COEFFICIENT;
   game.animFrame++;
 
   const level = Math.floor(game.score / GAME_CONFIG.SCORE_PER_LEVEL);
@@ -1594,6 +1609,7 @@ if (typeof process !== 'undefined' && process.versions && process.versions.node)
   global.dailySeed = dailySeed;
   global.dailyNumber = dailyNumber;
   global.ScoreStore = ScoreStore;
+  global.migrateScoreScale = migrateScoreScale;
   global.isDailyMode = isDailyMode;
   global.shareDailyResult = shareDailyResult;
   global.MS_PER_STEP = MS_PER_STEP;

--- a/script.js
+++ b/script.js
@@ -75,8 +75,8 @@ const GAME_CONFIG = Object.freeze({
   CANVAS_H: 200,
 
   // --- Physics ---
-  JUMP_POWER:              -12,   // negative = upward impulse applied on jump
-  GRAVITY:                  0.48, // added to velocityY each frame while airborne
+  JUMP_POWER:              -10,   // negative = upward impulse applied on jump (official)
+  GRAVITY:                  0.6,  // added to velocityY each frame while airborne (official)
   INITIAL_SPEED:            3.0,  // obstacle scroll speed at score 0
   SPEED_CAP:               13.0,  // max scroll speed (matches Chrome T-Rex)
   PLATEAU_SPEED:            8.0,  // sigmoid ceiling — focusable-but-demanding speed the curve approaches

--- a/script.js
+++ b/script.js
@@ -1435,6 +1435,8 @@ function handleRunning() {
   updateObstacles();
 
   // Speed-trail particles: subtle dust trailing off the dino approaching plateau speed.
+  // Speed-trail particles kick in once the run is ~85% of the way to SPEED_CAP —
+  // a late-game cue that the speed ceiling is approaching.
   if (isUpdatedMode() && game.currentSpeed >= GAME_CONFIG.SPEED_CAP * 0.85) {
     Particles.emit('trail', dino.x + 4, dino.y + dino.height - 4);
   }

--- a/script.js
+++ b/script.js
@@ -92,12 +92,10 @@ const GAME_CONFIG = Object.freeze({
   OBS_PAD_X:                3,
   OBS_PAD_Y:                2,
 
-  // --- Spawning ---
+  // --- Spawning (official gap model) ---
   GRACE_FRAMES:           240,    // ~4 s at 60 fps before first obstacle appears
-  MAX_SPAWN_GAP:          600,    // gap (px) between obstacles at INITIAL_SPEED
-  MIN_SPAWN_GAP:          340,    // gap (px) at SPEED_CAP — tuned minimum that's still clearable
-  SPAWN_GAP_SPEED_FACTOR:  50,    // gap shrinks by this much per +1 speed above INITIAL_SPEED
-  SPAWN_GAP_JITTER:         0.3,  // ±30% randomization; floored at MIN_SPAWN_GAP
+  GAP_COEFFICIENT:          0.6,  // official: minGap = width*speed + typeMinGap*GAP_COEFFICIENT
+  MAX_GAP_COEFFICIENT:      1.5,  // official: gap randomized up to minGap * this
 
   // --- Obstacle sprite (small cactus — baseline) ---
   OBS_WIDTH:               20,
@@ -108,9 +106,9 @@ const GAME_CONFIG = Object.freeze({
   // weighted random pick once unlocked. `render` controls how drawObstacles()
   // paints it from the single cactus sprite.
   OBSTACLE_TYPES: Object.freeze([
-    Object.freeze({ id: 'small',   width: 20, height: 40, unlockScore:   0, weight: 50, render: 'single' }),
-    Object.freeze({ id: 'big',     width: 30, height: 55, unlockScore: 100, weight: 30, render: 'single' }),
-    Object.freeze({ id: 'cluster', width: 50, height: 40, unlockScore: 250, weight: 20, render: 'double' }),
+    Object.freeze({ id: 'small',   width: 20, height: 40, unlockScore:   0, weight: 50, render: 'single', minGap: 120 }),
+    Object.freeze({ id: 'big',     width: 30, height: 55, unlockScore: 100, weight: 30, render: 'single', minGap: 120 }),
+    Object.freeze({ id: 'cluster', width: 50, height: 40, unlockScore: 250, weight: 20, render: 'double', minGap: 150 }),
   ]),
 
   // --- Dino sprite ---
@@ -437,19 +435,14 @@ function mulberry32(seed) {
   };
 }
 
-// Compute the gap (px) to the next obstacle, given current speed + an RNG.
-// Jitter is applied ±SPAWN_GAP_JITTER around baseGap, then floored at
-// MIN_SPAWN_GAP so the smallest possible gap is always clearable. In classic
-// mode, jitter is skipped — gaps are deterministic.
-function computeNextSpawnGap(rng, currentSpeed, mode) {
-  const baseGap =
-    GAME_CONFIG.MAX_SPAWN_GAP -
-    (currentSpeed - GAME_CONFIG.INITIAL_SPEED) * GAME_CONFIG.SPAWN_GAP_SPEED_FACTOR;
-  if (mode === 'classic') {
-    return Math.max(GAME_CONFIG.MIN_SPAWN_GAP, Math.round(baseGap));
-  }
-  const jitter = (rng() - 0.5) * 2 * GAME_CONFIG.SPAWN_GAP_JITTER; // range [-J, +J]
-  return Math.max(GAME_CONFIG.MIN_SPAWN_GAP, Math.round(baseGap * (1 + jitter)));
+// Official gap model: gap scales with the chosen obstacle's width and the current
+// speed, randomized within [minGap, minGap*MAX_GAP_COEFFICIENT]. The rng() draw is
+// the second seeded call per spawn (type pick is first) — order is load-bearing
+// for the daily-challenge determinism contract.
+function computeNextSpawnGap(rng, speed, type) {
+  const minGap = Math.round(type.width * speed + type.minGap * GAME_CONFIG.GAP_COEFFICIENT);
+  const maxGap = Math.round(minGap * GAME_CONFIG.MAX_GAP_COEFFICIENT);
+  return minGap + Math.floor(rng() * (maxGap - minGap + 1));
 }
 
 // Pick an obstacle type weighted by score-tier eligibility. Types with
@@ -474,14 +467,12 @@ const DifficultyProfile = {
     return INITIAL_SPEED + (PLATEAU_SPEED - INITIAL_SPEED) *
       (1 / (1 + Math.exp(-RAMP_STEEPNESS * (score - RAMP_MIDPOINT))));
   },
-  nextObstacle(score, mode, rng) {
-    const speed = this.speedAtScore(score);
-    // RNG call order is load-bearing: type roll first, gap jitter second.
-    // Swapping breaks the daily-challenge seed sequence.
+  nextObstacle(score, mode, rng, speed) {
+    // RNG call order is load-bearing: type roll first, gap roll second.
     const type = pickObstacleType(rng, score, mode);
     return {
       type,
-      gap: computeNextSpawnGap(rng, speed, mode),
+      gap: computeNextSpawnGap(rng, speed, type),
     };
   },
 };
@@ -518,7 +509,7 @@ const game = {
   obstacles:        [],
   currentSpeed:     GAME_CONFIG.INITIAL_SPEED,
   lastObstacleX:    -300,
-  nextSpawnGap:     GAME_CONFIG.MAX_SPAWN_GAP,
+  nextSpawnGap:     0,            // set by resetGame() via computeNextSpawnGap
   graceFrames:      GAME_CONFIG.GRACE_FRAMES,
   animationFrameId: undefined,
   score:            0,
@@ -1333,7 +1324,7 @@ function resetGame() {
   game.dailyBest = ScoreStore.loadDailyBest();
   const shareBtnEl = document.getElementById('share-btn');
   if (shareBtnEl && shareBtnEl.style) shareBtnEl.style.display = 'none';
-  game.nextSpawnGap = computeNextSpawnGap(game.rng, DifficultyProfile.speedAtScore(game.score), game.mode);
+  game.nextSpawnGap = computeNextSpawnGap(game.rng, game.currentSpeed, GAME_CONFIG.OBSTACLE_TYPES[0]);
   initClouds();
   initHills();
   announce('New game. Press space or tap to jump.');
@@ -1437,11 +1428,11 @@ function handleRunning() {
     Particles.emit('trail', dino.x + 4, dino.y + dino.height - 4);
   }
 
-  // Obstacle spawning — in updated mode the gap is precomputed per-obstacle
-  // with ±SPAWN_GAP_JITTER so spacing doesn't feel metronomic; in classic mode
-  // it's deterministic. DifficultyProfile.nextObstacle() picks type + gap together.
+  // Obstacle spawning — gap is computed via the official model (width*speed + minGap*GAP_COEFFICIENT),
+  // randomized within [minGap, minGap*MAX_GAP_COEFFICIENT]. DifficultyProfile.nextObstacle() picks
+  // type first (one rng draw), then computes the gap from that type (second rng draw).
   if (game.lastObstacleX <= GAME_CONFIG.CANVAS_W - game.nextSpawnGap) {
-    const params = DifficultyProfile.nextObstacle(game.score, game.mode, game.rng);
+    const params = DifficultyProfile.nextObstacle(game.score, game.mode, game.rng, game.currentSpeed);
     spawnObstacle(params.type);
     game.lastObstacleX = GAME_CONFIG.CANVAS_W;
     game.nextSpawnGap = params.gap;

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -854,7 +854,7 @@ describe('Day/Night Cycle', () => {
     // Distance-based scoring: score = distance * DISTANCE_COEFFICIENT.
     // Set distance so score is at 400 when handleRunning reads it.
     game.distance = 400 / GAME_CONFIG.DISTANCE_COEFFICIENT;
-    game.score = 400;
+    game.score = game.distance * GAME_CONFIG.DISTANCE_COEFFICIENT;
     game.state = STATE.RUNNING;
     game.graceFrames = 0;
     gameLoop();

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -398,6 +398,13 @@ describe('Ambient depth + confetti (PR-D)', () => {
     game.state = STATE.RUNNING;
     game.graceFrames = 0;
     Particles.reset();
+    // Set distance so that after handleRunning adds currentSpeed the score crosses SCORE_PER_LEVEL.
+    // score = distance * DISTANCE_COEFFICIENT, so we need:
+    //   (distance + currentSpeed) * DISTANCE_COEFFICIENT >= SCORE_PER_LEVEL
+    // Priming distance to (SCORE_PER_LEVEL - 0.05) / DISTANCE_COEFFICIENT ensures the boundary
+    // is genuinely crossed in the tick — the gate being tested is Particles.emit's isUpdatedMode()
+    // check, not a miss of the milestone branch.
+    game.distance = (GAME_CONFIG.SCORE_PER_LEVEL - 0.05) / GAME_CONFIG.DISTANCE_COEFFICIENT;
     game.score = GAME_CONFIG.SCORE_PER_LEVEL - 0.05;
     gameLoop();
     cancelAnimationFrame(game.animationFrameId);

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -404,8 +404,7 @@ describe('Ambient depth + confetti (PR-D)', () => {
     // Priming distance to (SCORE_PER_LEVEL - 0.05) / DISTANCE_COEFFICIENT ensures the boundary
     // is genuinely crossed in the tick — the gate being tested is Particles.emit's isUpdatedMode()
     // check, not a miss of the milestone branch.
-    game.distance = (GAME_CONFIG.SCORE_PER_LEVEL - 0.05) / GAME_CONFIG.DISTANCE_COEFFICIENT;
-    game.score = GAME_CONFIG.SCORE_PER_LEVEL - 0.05;
+    game.distance = (GAME_CONFIG.SCORE_PER_LEVEL - 0.05) / GAME_CONFIG.DISTANCE_COEFFICIENT; // crosses level boundary on next step
     gameLoop();
     cancelAnimationFrame(game.animationFrameId);
     const gold = Particles.particles.filter(p => p.life > 0 && p.color === '#ffd700').length;
@@ -667,17 +666,25 @@ describe('Mode Toggle', () => {
     }
   });
 
-  it('classic mode returns deterministic gap (no jitter)', () => {
-    const rng = () => 0; // constant rng → both calls produce the same gap roll (determinism check)
+  it('classic mode gap uses the official band (rng-driven)', () => {
+    // Classic mode runs the same official gap formula as updated mode; the old
+    // "no-jitter" carve-out is gone (chrome://dino itself jitters spacing).
+    // Verify: gaps stay within [minGap, minGap*MAX_GAP_COEFFICIENT] and the
+    // seeded rng produces real variety.
+    const rng = mulberry32(2026);
     const speed = GAME_CONFIG.INITIAL_SPEED;
-    const a = DifficultyProfile.nextObstacle(0, MODES.CLASSIC, rng, speed).gap;
-    const b = DifficultyProfile.nextObstacle(0, MODES.CLASSIC, rng, speed).gap;
-    assertEquals(a, b, 'Classic gap should not vary');
-    const type = GAME_CONFIG.OBSTACLE_TYPES[0]; // classic always picks small
-    const minGap = Math.round(type.width * speed + type.minGap * GAME_CONFIG.GAP_COEFFICIENT);
+    const small = GAME_CONFIG.OBSTACLE_TYPES[0]; // classic only ever spawns small
+    const minGap = Math.round(small.width * speed + small.minGap * GAME_CONFIG.GAP_COEFFICIENT);
     const maxGap = Math.round(minGap * GAME_CONFIG.MAX_GAP_COEFFICIENT);
-    assert(a >= minGap && a <= maxGap,
-      `Classic gap at score 0 (${a}) should be within [${minGap}, ${maxGap}]`);
+
+    const gaps = new Set();
+    for (let i = 0; i < 50; i++) {
+      const { type, gap } = DifficultyProfile.nextObstacle(0, MODES.CLASSIC, rng, speed);
+      assertEquals(type.id, 'small', 'classic mode must only spawn the small cactus');
+      assert(gap >= minGap && gap <= maxGap, `gap ${gap} must be in band [${minGap}, ${maxGap}]`);
+      gaps.add(gap);
+    }
+    assert(gaps.size >= 5, `seeded rng should produce gap variety in classic; got ${gaps.size} distinct values`);
   });
 
   it('updated mode still produces variety', () => {

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -223,82 +223,69 @@ describe('Scoring', () => {
 });
 
 describe('Obstacle Gap Enforcement', () => {
-  it('should not spawn a second obstacle until the dynamic gap threshold is met', () => {
+  it('does not spawn a second obstacle until the official gap threshold is met', () => {
     resetGame();
     game.graceFrames = 0;
     game.state = STATE.RUNNING;
-    // Pin the RNG to the middle of the jitter range so nextSpawnGap is deterministic.
-    game.rng = () => 0.5;
-    game.nextSpawnGap = 600; // base gap at INITIAL_SPEED, zero jitter — triggers first spawn
+    game.rng = () => 0.5;                 // mid-range gap roll, deterministic
+    game.currentSpeed = GAME_CONFIG.INITIAL_SPEED;
+    game.nextSpawnGap = 100;             // small threshold so frame 1 spawns
 
-    // Frame 1: lastObstacleX=-300 ≤ GAME_CONFIG.CANVAS_W-600 → first spawn
-    gameLoop();
-    cancelAnimationFrame(game.animationFrameId);
-    assertEquals(game.obstacles.length, 1, 'Should have 1 obstacle after first gameLoop frame');
+    gameLoop(); cancelAnimationFrame(game.animationFrameId);
+    assertEquals(game.obstacles.length, 1, 'first obstacle spawns on frame 1');
 
-    // After spawn, nextSpawnGap was recomputed via DifficultyProfile.nextObstacle(score=0).
-    // At rng=0.5 jitter is zero, so gap = round(MAX_SPAWN_GAP - (speed - INITIAL_SPEED) * FACTOR).
-    const expectedGap = Math.round(
-      GAME_CONFIG.MAX_SPAWN_GAP -
-      (DifficultyProfile.speedAtScore(0) - GAME_CONFIG.INITIAL_SPEED) * GAME_CONFIG.SPAWN_GAP_SPEED_FACTOR
-    );
-    assertEquals(game.nextSpawnGap, expectedGap, `Next gap should be ${expectedGap} at speedAtScore(0) with zero jitter`);
+    // Recomputed gap must sit within the official band for the spawned type at this speed.
+    const type   = game.obstacles[0].type ? GAME_CONFIG.OBSTACLE_TYPES.find(t => t.id === game.obstacles[0].type) : GAME_CONFIG.OBSTACLE_TYPES[0];
+    const minGap = Math.round(type.width * game.currentSpeed + type.minGap * GAME_CONFIG.GAP_COEFFICIENT);
+    const maxGap = Math.round(minGap * GAME_CONFIG.MAX_GAP_COEFFICIENT);
+    assert(game.nextSpawnGap >= minGap && game.nextSpawnGap <= maxGap,
+      `recomputed gap ${game.nextSpawnGap} must be in [${minGap}, ${maxGap}]`);
 
-    // Frame 2: obstacle hasn't drifted far enough yet — not a spawn frame.
-    gameLoop();
-    cancelAnimationFrame(game.animationFrameId);
-    assertEquals(game.obstacles.length, 1, `Should still be 1 obstacle — ${expectedGap}px gap not met`);
+    gameLoop(); cancelAnimationFrame(game.animationFrameId);
+    assertEquals(game.obstacles.length, 1, 'no new obstacle until gap distance elapses');
 
-    // Force obstacle just past the threshold
     game.obstacles[0].x = GAME_CONFIG.CANVAS_W - (game.nextSpawnGap + 1);
-    game.lastObstacleX = game.obstacles[0].x;
-
-    gameLoop();
-    cancelAnimationFrame(game.animationFrameId);
-    assertEquals(game.obstacles.length, 2, 'Should now be 2 obstacles — gap threshold met');
+    game.lastObstacleX  = game.obstacles[0].x;
+    gameLoop(); cancelAnimationFrame(game.animationFrameId);
+    assertEquals(game.obstacles.length, 2, 'second obstacle spawns once gap threshold met');
   });
 });
 
-describe('Spawn Gap Jitter', () => {
-  it('nextObstacle gap stays within [MIN_SPAWN_GAP, baseGap * (1 + JITTER)]', () => {
-    const scores = [0, 200, 500];
-    scores.forEach(score => {
-      const speed = DifficultyProfile.speedAtScore(score);
-      const baseGap = Math.max(
-        GAME_CONFIG.MIN_SPAWN_GAP,
-        GAME_CONFIG.MAX_SPAWN_GAP - (speed - GAME_CONFIG.INITIAL_SPEED) * GAME_CONFIG.SPAWN_GAP_SPEED_FACTOR
-      );
-      const upperBound = Math.round(baseGap * (1 + GAME_CONFIG.SPAWN_GAP_JITTER));
-      const rng = mulberry32(12345);
-      for (let i = 0; i < 500; i++) {
-        const { gap } = DifficultyProfile.nextObstacle(score, MODES.UPDATED, rng);
-        assert(
-          gap >= GAME_CONFIG.MIN_SPAWN_GAP && gap <= upperBound,
-          `At score ${score}, gap ${gap} should be in [${GAME_CONFIG.MIN_SPAWN_GAP}, ${upperBound}]`
-        );
-      }
-    });
+describe('Spawn Gap (official model)', () => {
+  function band(type, speed) {
+    const minGap = Math.round(type.width * speed + type.minGap * GAME_CONFIG.GAP_COEFFICIENT);
+    return { minGap, maxGap: Math.round(minGap * GAME_CONFIG.MAX_GAP_COEFFICIENT) };
+  }
+
+  it('gap stays within [minGap, minGap*MAX_GAP_COEFFICIENT] for the chosen type', () => {
+    const speed = 8;
+    const rng = mulberry32(12345);
+    for (let i = 0; i < 500; i++) {
+      const { type, gap } = DifficultyProfile.nextObstacle(300, MODES.UPDATED, rng, speed);
+      const { minGap, maxGap } = band(type, speed);
+      assert(gap >= minGap && gap <= maxGap,
+        `gap ${gap} for type ${type.id} at speed ${speed} must be in [${minGap}, ${maxGap}]`);
+    }
   });
 
-  it('produces different gaps across spawns (breaks the metronome)', () => {
+  it('gap grows with speed (official: width*speed dominates)', () => {
+    const rng = () => 0.5;  // fixed mid roll isolates the speed term
+    const slow = DifficultyProfile.nextObstacle(0, MODES.CLASSIC, rng, 6);
+    const fast = DifficultyProfile.nextObstacle(0, MODES.CLASSIC, rng, 13);
+    assert(fast.gap > slow.gap,
+      `gap at speed 13 (${fast.gap}) should exceed gap at speed 6 (${slow.gap})`);
+  });
+
+  it('produces gap variety across spawns (breaks the metronome)', () => {
     const rng = mulberry32(7);
     const gaps = new Set();
-    for (let i = 0; i < 50; i++) gaps.add(DifficultyProfile.nextObstacle(100, MODES.UPDATED, rng).gap);
-    assert(gaps.size >= 5, `Expected gap variety; got ${gaps.size} distinct values across 50 draws`);
-  });
-
-  it('smallest achievable gap is still at least MIN_SPAWN_GAP (always clearable)', () => {
-    // Force rng to 0 → maximum negative jitter on the gap roll.
-    const worstCaseRng = () => 0;
-    const { gap } = DifficultyProfile.nextObstacle(500, MODES.UPDATED, worstCaseRng);
-    assert(gap >= GAME_CONFIG.MIN_SPAWN_GAP,
-      `At max negative jitter + near-plateau speed, gap ${gap} must be >= MIN_SPAWN_GAP ${GAME_CONFIG.MIN_SPAWN_GAP}`);
+    for (let i = 0; i < 50; i++) gaps.add(DifficultyProfile.nextObstacle(100, MODES.UPDATED, rng, 8).gap);
+    assert(gaps.size >= 5, `expected gap variety; got ${gaps.size} distinct values`);
   });
 
   it('mulberry32 is deterministic given same seed', () => {
-    const a = mulberry32(42);
-    const b = mulberry32(42);
-    for (let i = 0; i < 10; i++) assertEquals(a(), b(), 'Same seed should produce same sequence');
+    const a = mulberry32(42), b = mulberry32(42);
+    for (let i = 0; i < 10; i++) assertEquals(a(), b(), 'same seed → same sequence');
   });
 });
 
@@ -646,18 +633,22 @@ describe('Mode Toggle', () => {
   });
 
   it('classic mode returns deterministic gap (no jitter)', () => {
-    const rng = () => 0; // worst-case jitter input — should have no effect in classic
-    const a = DifficultyProfile.nextObstacle(0, MODES.CLASSIC, rng).gap;
-    const b = DifficultyProfile.nextObstacle(0, MODES.CLASSIC, rng).gap;
+    const rng = () => 0; // rng value should have no effect in classic
+    const speed = GAME_CONFIG.INITIAL_SPEED;
+    const a = DifficultyProfile.nextObstacle(0, MODES.CLASSIC, rng, speed).gap;
+    const b = DifficultyProfile.nextObstacle(0, MODES.CLASSIC, rng, speed).gap;
     assertEquals(a, b, 'Classic gap should not vary');
-    assert(a >= GAME_CONFIG.MIN_SPAWN_GAP && a <= GAME_CONFIG.MAX_SPAWN_GAP,
-      `Classic gap at score 0 (${a}) should be within [MIN_SPAWN_GAP, MAX_SPAWN_GAP]`);
+    const type = GAME_CONFIG.OBSTACLE_TYPES[0]; // classic always picks small
+    const minGap = Math.round(type.width * speed + type.minGap * GAME_CONFIG.GAP_COEFFICIENT);
+    const maxGap = Math.round(minGap * GAME_CONFIG.MAX_GAP_COEFFICIENT);
+    assert(a >= minGap && a <= maxGap,
+      `Classic gap at score 0 (${a}) should be within [${minGap}, ${maxGap}]`);
   });
 
   it('updated mode still produces variety', () => {
     const rng = mulberry32(11);
     const gaps = new Set();
-    for (let i = 0; i < 30; i++) gaps.add(DifficultyProfile.nextObstacle(200, MODES.UPDATED, rng).gap);
+    for (let i = 0; i < 30; i++) gaps.add(DifficultyProfile.nextObstacle(200, MODES.UPDATED, rng, 8).gap);
     assert(gaps.size >= 5, `Updated mode should jitter; got ${gaps.size} distinct values`);
   });
 
@@ -1584,44 +1575,40 @@ describe('DifficultyProfile', () => {
       `Speed must strictly increase: ${s0} < ${s100} < ${s300} < ${s600}`);
   });
 
-  it('nextObstacle returns an object with a numeric gap and a typed obstacle', () => {
+  it('nextObstacle returns a numeric gap and a typed obstacle', () => {
     const rng = mulberry32(42);
-    const params = DifficultyProfile.nextObstacle(0, MODES.CLASSIC, rng);
-    assert(typeof params.gap === 'number',
-      'gap must be a number');
-    assert(params.type && typeof params.type.id === 'string',
-      'type must be an obstacle-type object with an id string');
+    const params = DifficultyProfile.nextObstacle(0, MODES.CLASSIC, rng, 6);
+    assert(typeof params.gap === 'number', 'gap must be a number');
+    assert(params.type && typeof params.type.id === 'string', 'type must have an id string');
   });
 
-  it('nextObstacle classic mode: gap shrinks as score rises', () => {
-    const rng = mulberry32(42); // not consumed in classic mode — safe to reuse
-    const paramsLow  = DifficultyProfile.nextObstacle(0,   MODES.CLASSIC, rng);
-    const paramsHigh = DifficultyProfile.nextObstacle(500, MODES.CLASSIC, rng);
-    assert(paramsHigh.gap < paramsLow.gap,
-      `Gap at score 500 (${paramsHigh.gap}) should be less than gap at score 0 (${paramsLow.gap}) — higher speed means shorter gap`);
+  it('nextObstacle classic mode: gap grows as speed rises', () => {
+    const rng = () => 0.5;
+    const low  = DifficultyProfile.nextObstacle(0, MODES.CLASSIC, rng, 6);
+    const high = DifficultyProfile.nextObstacle(0, MODES.CLASSIC, rng, 13);
+    assert(high.gap > low.gap, `gap at speed 13 (${high.gap}) should exceed speed 6 (${low.gap})`);
   });
 
   it('nextObstacle classic mode: type is always small cactus', () => {
     const rng = mulberry32(42);
-    const params = DifficultyProfile.nextObstacle(500, MODES.CLASSIC, rng);
-    assertEquals(params.type.id, 'small',
-      'Classic mode must always return the small cactus');
+    const params = DifficultyProfile.nextObstacle(500, MODES.CLASSIC, rng, 10);
+    assertEquals(params.type.id, 'small', 'classic mode always returns the small cactus');
   });
 
-  it('nextObstacle updated mode: gap is within valid range at score 0', () => {
+  it('nextObstacle updated mode: gap within official band at low speed', () => {
     const rng = mulberry32(42);
-    const params = DifficultyProfile.nextObstacle(0, MODES.UPDATED, rng);
-    assert(params.gap >= GAME_CONFIG.MIN_SPAWN_GAP,
-      `Gap (${params.gap}) must be at least MIN_SPAWN_GAP (${GAME_CONFIG.MIN_SPAWN_GAP})`);
-    assert(params.gap <= Math.round(GAME_CONFIG.MAX_SPAWN_GAP * (1 + GAME_CONFIG.SPAWN_GAP_JITTER)),
-      `Gap (${params.gap}) must not exceed MAX_SPAWN_GAP with max jitter (${GAME_CONFIG.MAX_SPAWN_GAP} * ${1 + GAME_CONFIG.SPAWN_GAP_JITTER})`);
+    const speed = 6;
+    const params = DifficultyProfile.nextObstacle(0, MODES.UPDATED, rng, speed);
+    const minGap = Math.round(params.type.width * speed + params.type.minGap * GAME_CONFIG.GAP_COEFFICIENT);
+    const maxGap = Math.round(minGap * GAME_CONFIG.MAX_GAP_COEFFICIENT);
+    assert(params.gap >= minGap && params.gap <= maxGap,
+      `gap ${params.gap} must be in [${minGap}, ${maxGap}]`);
   });
 
   it('nextObstacle updated mode: cluster cactus returned at score 250 with max roll', () => {
-    const rng = () => 0.99; // constant roll — pushes weighted pick to last eligible type
-    const params = DifficultyProfile.nextObstacle(250, MODES.UPDATED, rng);
-    assertEquals(params.type.id, 'cluster',
-      'At score 250 with max rng roll, all three types eligible and cluster wins the weighted draw');
+    const rng = () => 0.99;  // type pick (call 1) → last eligible; gap roll (call 2) → top of band
+    const params = DifficultyProfile.nextObstacle(250, MODES.UPDATED, rng, 8);
+    assertEquals(params.type.id, 'cluster', 'at score 250 with max roll, cluster wins the weighted draw');
   });
 });
 

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -2100,7 +2100,7 @@ describe('Fixed-timestep loop', () => {
     const start = game.animFrame;
     let t = 1000; gameLoop(t); cancelAnimationFrame(game.animationFrameId);   // baseline
     t += 100;     gameLoop(t); cancelAnimationFrame(game.animationFrameId);   // 100ms → 6 wanted, clamp 5
-    assert(game.animFrame - start <= 5, `catch-up must clamp to 5 steps, got ${game.animFrame - start}`);
+    assert(game.animFrame - start <= MAX_CATCHUP_STEPS, `catch-up must clamp to ${MAX_CATCHUP_STEPS} steps, got ${game.animFrame - start}`);
   });
 
   it('treats a backgrounded-tab gap as a single step', () => {
@@ -2109,6 +2109,15 @@ describe('Fixed-timestep loop', () => {
     let t = 1000; gameLoop(t);  cancelAnimationFrame(game.animationFrameId);  // baseline
     t += 5000;    gameLoop(t);  cancelAnimationFrame(game.animationFrameId);  // 5s gap → frame>250 → 1 step
     assertEquals(game.animFrame - start, 1, 'a >250ms frame should advance exactly one step');
+  });
+
+  it('ignores a bogus (NaN) timestamp without freezing the clock', () => {
+    resetGame(); game.graceFrames = 0; game.state = STATE.RUNNING; game.rng = mulberry32(1);
+    const start = game.animFrame;
+    let t = 1000; gameLoop(t); cancelAnimationFrame(game.animationFrameId);   // baseline
+    gameLoop(NaN);            cancelAnimationFrame(game.animationFrameId);     // bogus — must be ignored
+    for (let i = 0; i < 4; i++) { t += 1000 / 60; gameLoop(t); cancelAnimationFrame(game.animationFrameId); }
+    assert(game.animFrame - start >= 3, `clock must keep stepping after a NaN timestamp, got ${game.animFrame - start} steps`);
   });
 });
 

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -113,11 +113,11 @@ describe('Dinosaur Jump', () => {
     assertEquals(dino.y, GAME_CONFIG.CANVAS_H - dino.height, 'Dino should be back on the ground after landing');
   });
 
-  it('should have a peak jump height of ~144px', () => {
-    // jumpPower=-12, gravity=0.48 → peak ≈ 144px
+  it('should have a peak jump height of ~78px', () => {
+    // jumpPower=-10, gravity=0.6 → discrete peak ≈ 78px (official-feel snappy arc)
     resetGame();
     game.state = STATE.RUNNING;
-    const expectedPeak = 144;
+    const expectedPeak = 78;
     jump();
     let minY = dino.y;
     const groundY = GAME_CONFIG.CANVAS_H - dino.height;

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -626,14 +626,14 @@ describe('Mode Toggle', () => {
     const rng = mulberry32(99);
     for (const score of [0, 100, 250, 1000]) {
       for (let i = 0; i < 50; i++) {
-        const { type } = DifficultyProfile.nextObstacle(score, MODES.CLASSIC, rng);
+        const { type } = DifficultyProfile.nextObstacle(score, MODES.CLASSIC, rng, 8);
         assertEquals(type.id, 'small', `Classic@${score}: expected small, got ${type.id}`);
       }
     }
   });
 
   it('classic mode returns deterministic gap (no jitter)', () => {
-    const rng = () => 0; // rng value should have no effect in classic
+    const rng = () => 0; // constant rng → both calls produce the same gap roll (determinism check)
     const speed = GAME_CONFIG.INITIAL_SPEED;
     const a = DifficultyProfile.nextObstacle(0, MODES.CLASSIC, rng, speed).gap;
     const b = DifficultyProfile.nextObstacle(0, MODES.CLASSIC, rng, speed).gap;
@@ -667,7 +667,7 @@ describe('Obstacle Types', () => {
   it('only returns small cactus when score < 100', () => {
     const rng = mulberry32(1);
     for (let i = 0; i < 200; i++) {
-      const { type } = DifficultyProfile.nextObstacle(50, MODES.UPDATED, rng);
+      const { type } = DifficultyProfile.nextObstacle(50, MODES.UPDATED, rng, 8);
       assertEquals(type.id, 'small', `At score 50 expected small, got ${type.id}`);
     }
   });
@@ -675,7 +675,7 @@ describe('Obstacle Types', () => {
   it('can return big cactus at score 100+ but never cluster before 250', () => {
     const rng = mulberry32(2);
     const seen = new Set();
-    for (let i = 0; i < 500; i++) seen.add(DifficultyProfile.nextObstacle(150, MODES.UPDATED, rng).type.id);
+    for (let i = 0; i < 500; i++) seen.add(DifficultyProfile.nextObstacle(150, MODES.UPDATED, rng, 8).type.id);
     assert(seen.has('small') && seen.has('big'), `Expected small+big at score 150, saw ${[...seen]}`);
     assert(!seen.has('cluster'), `Cluster should not appear before score 250, saw ${[...seen]}`);
   });
@@ -683,7 +683,7 @@ describe('Obstacle Types', () => {
   it('can return all three types at score 250+', () => {
     const rng = mulberry32(3);
     const seen = new Set();
-    for (let i = 0; i < 2000; i++) seen.add(DifficultyProfile.nextObstacle(300, MODES.UPDATED, rng).type.id);
+    for (let i = 0; i < 2000; i++) seen.add(DifficultyProfile.nextObstacle(300, MODES.UPDATED, rng, 8).type.id);
     assert(seen.has('small') && seen.has('big') && seen.has('cluster'),
       `Expected all 3 types at score 300, saw ${[...seen]}`);
   });
@@ -692,7 +692,7 @@ describe('Obstacle Types', () => {
     const rng = mulberry32(4);
     const counts = { small: 0, big: 0, cluster: 0 };
     const total = 20000;
-    for (let i = 0; i < total; i++) counts[DifficultyProfile.nextObstacle(300, MODES.UPDATED, rng).type.id]++;
+    for (let i = 0; i < total; i++) counts[DifficultyProfile.nextObstacle(300, MODES.UPDATED, rng, 8).type.id]++;
     const expected = { small: 0.5, big: 0.3, cluster: 0.2 };
     Object.keys(expected).forEach(id => {
       const observed = counts[id] / total;
@@ -1981,10 +1981,10 @@ describe('Daily mode RNG seeding', () => {
     const origMode = game.mode;
     game.mode = MODES.DAILY;
     resetGame();
-    const type1 = DifficultyProfile.nextObstacle(300, MODES.DAILY, game.rng).type;
+    const type1 = DifficultyProfile.nextObstacle(300, MODES.DAILY, game.rng, 8).type;
     game.mode = MODES.DAILY;
     resetGame();
-    const type2 = DifficultyProfile.nextObstacle(300, MODES.DAILY, game.rng).type;
+    const type2 = DifficultyProfile.nextObstacle(300, MODES.DAILY, game.rng, 8).type;
     assertEquals(type1.id, type2.id, 'Same seed should produce same obstacle type');
     game.mode = origMode;
     resetGame();

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -740,19 +740,20 @@ describe('Obstacle Types', () => {
 });
 
 describe('Difficulty Curve', () => {
-  it('currentSpeed approaches PLATEAU_SPEED at high score and never exceeds it', () => {
-    resetGame();
-    game.state = STATE.RUNNING;
-    game.graceFrames = 0;
+  it('currentSpeed accelerates by ACCELERATION each step and caps at SPEED_CAP', () => {
+    resetGame(); game.state = STATE.RUNNING; game.graceFrames = 0;
+    const s0 = game.currentSpeed;
+    assertEquals(s0, GAME_CONFIG.INITIAL_SPEED, 'run starts at INITIAL_SPEED');
 
-    game.score = 2000;
-    gameLoop();
-    cancelAnimationFrame(game.animationFrameId);
+    gameLoop(); cancelAnimationFrame(game.animationFrameId);
+    game.obstacles.length = 0;   // keep the dino alive for the rest of the checks
+    assert(Math.abs(game.currentSpeed - (s0 + GAME_CONFIG.ACCELERATION)) < 1e-9,
+      `one step should add ACCELERATION; got ${game.currentSpeed} from ${s0}`);
 
-    assert(game.currentSpeed <= GAME_CONFIG.PLATEAU_SPEED,
-      `currentSpeed at score 2000 (${game.currentSpeed}) must not exceed PLATEAU_SPEED (${GAME_CONFIG.PLATEAU_SPEED})`);
-    assert(game.currentSpeed > GAME_CONFIG.PLATEAU_SPEED - 0.1,
-      `currentSpeed at score 2000 (${game.currentSpeed}) should be very close to PLATEAU_SPEED — sigmoid has converged`);
+    game.currentSpeed = GAME_CONFIG.SPEED_CAP - GAME_CONFIG.ACCELERATION / 2;
+    game.obstacles.length = 0;
+    gameLoop(); cancelAnimationFrame(game.animationFrameId);
+    assertEquals(game.currentSpeed, GAME_CONFIG.SPEED_CAP, 'speed clamps at SPEED_CAP');
   });
 
   it('should not set a .speed property on spawned obstacles', () => {
@@ -1541,40 +1542,6 @@ describe('Hill colour interpolation (polish pass)', () => {
 });
 
 describe('DifficultyProfile', () => {
-  it('speedAtScore returns exactly the midpoint speed at RAMP_MIDPOINT', () => {
-    const expected = GAME_CONFIG.INITIAL_SPEED +
-      (GAME_CONFIG.PLATEAU_SPEED - GAME_CONFIG.INITIAL_SPEED) / 2;
-    assertEquals(
-      DifficultyProfile.speedAtScore(GAME_CONFIG.RAMP_MIDPOINT), expected,
-      'At RAMP_MIDPOINT the sigmoid is exactly 0.5, so speed must be the midpoint between INITIAL and PLATEAU'
-    );
-  });
-
-  it('speedAtScore is slightly above INITIAL_SPEED at score 0 — curve starts gently', () => {
-    const speed = DifficultyProfile.speedAtScore(0);
-    assert(speed > GAME_CONFIG.INITIAL_SPEED,
-      `Score 0 speed ${speed} should be above INITIAL_SPEED ${GAME_CONFIG.INITIAL_SPEED}`);
-    assert(speed < GAME_CONFIG.INITIAL_SPEED + 0.5,
-      `Score 0 speed ${speed} should still be close to INITIAL_SPEED — gentle start`);
-  });
-
-  it('speedAtScore never exceeds PLATEAU_SPEED', () => {
-    for (const score of [500, 1000, 5000]) {
-      const speed = DifficultyProfile.speedAtScore(score);
-      assert(speed <= GAME_CONFIG.PLATEAU_SPEED,
-        `Score ${score} speed ${speed} must not exceed PLATEAU_SPEED ${GAME_CONFIG.PLATEAU_SPEED}`);
-    }
-  });
-
-  it('speedAtScore is monotonically increasing', () => {
-    const s0   = DifficultyProfile.speedAtScore(0);
-    const s100 = DifficultyProfile.speedAtScore(100);
-    const s300 = DifficultyProfile.speedAtScore(300);
-    const s600 = DifficultyProfile.speedAtScore(600);
-    assert(s0 < s100 && s100 < s300 && s300 < s600,
-      `Speed must strictly increase: ${s0} < ${s100} < ${s300} < ${s600}`);
-  });
-
   it('nextObstacle returns a numeric gap and a typed obstacle', () => {
     const rng = mulberry32(42);
     const params = DifficultyProfile.nextObstacle(0, MODES.CLASSIC, rng, 6);

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -2065,6 +2065,53 @@ describe('Daily best persistence', () => {
   });
 });
 
+describe('Fixed-timestep loop', () => {
+  const MS = 1000 / 60;
+
+  // Drive the loop with explicit timestamps and report how many physics
+  // steps (game.animFrame ticks) ran over the timeline.
+  function runTimeline(frameCount, deltaPerFrame) {
+    resetGame();
+    game.graceFrames = 0;
+    game.state = STATE.RUNNING;
+    game.rng = mulberry32(2024);      // pin RNG so both timelines spawn identically
+    const startAnim = game.animFrame;
+    let t = 1000;
+    gameLoop(t);                       // baseline frame — establishes lastTime, runs 0 steps
+    cancelAnimationFrame(game.animationFrameId);
+    for (let i = 0; i < frameCount; i++) {
+      t += deltaPerFrame;
+      gameLoop(t);
+      cancelAnimationFrame(game.animationFrameId);
+    }
+    return game.animFrame - startAnim;
+  }
+
+  it('runs the same number of physics steps per wall-clock second regardless of refresh rate', () => {
+    const steps60  = runTimeline(60,  MS);        // 60 frames * 16.67ms ≈ 1000ms
+    const steps144 = runTimeline(144, MS / 2.4);  // 144 frames * 6.94ms ≈ 1000ms
+    assert(steps60 >= 58 && steps60 <= 62,   `60Hz: expected ~60 steps, got ${steps60}`);
+    assert(steps144 >= 58 && steps144 <= 62, `144Hz: expected ~60 steps (not ~144), got ${steps144}`);
+    assert(Math.abs(steps60 - steps144) <= 2, `step counts must match across refresh rates: 60Hz=${steps60}, 144Hz=${steps144}`);
+  });
+
+  it('clamps catch-up to MAX_CATCHUP_STEPS on sustained slow frames', () => {
+    resetGame(); game.graceFrames = 0; game.state = STATE.RUNNING; game.rng = mulberry32(1);
+    const start = game.animFrame;
+    let t = 1000; gameLoop(t); cancelAnimationFrame(game.animationFrameId);   // baseline
+    t += 100;     gameLoop(t); cancelAnimationFrame(game.animationFrameId);   // 100ms → 6 wanted, clamp 5
+    assert(game.animFrame - start <= 5, `catch-up must clamp to 5 steps, got ${game.animFrame - start}`);
+  });
+
+  it('treats a backgrounded-tab gap as a single step', () => {
+    resetGame(); game.graceFrames = 0; game.state = STATE.RUNNING; game.rng = mulberry32(1);
+    const start = game.animFrame;
+    let t = 1000; gameLoop(t);  cancelAnimationFrame(game.animationFrameId);  // baseline
+    t += 5000;    gameLoop(t);  cancelAnimationFrame(game.animationFrameId);  // 5s gap → frame>250 → 1 step
+    assertEquals(game.animFrame - start, 1, 'a >250ms frame should advance exactly one step');
+  });
+});
+
 if (typeof window !== 'undefined' && typeof window.addEventListener === 'function') {
   window.addEventListener('load', () => setTimeout(printSummary, 500));
 } else {

--- a/tests/game.test.js
+++ b/tests/game.test.js
@@ -220,6 +220,30 @@ describe('Scoring', () => {
 
     assert(game.score > initialScore, `Score (${game.score}) should be greater than initial score (${initialScore})`);
   });
+
+  it('score equals accumulated distance times DISTANCE_COEFFICIENT', () => {
+    resetGame();
+    game.state = STATE.RUNNING;
+    game.graceFrames = 0;
+    for (let i = 0; i < 10; i++) { gameLoop(); cancelAnimationFrame(game.animationFrameId); }
+    assert(Math.abs(game.score - game.distance * GAME_CONFIG.DISTANCE_COEFFICIENT) < 1e-9,
+      `score ${game.score} must equal distance ${game.distance} * ${GAME_CONFIG.DISTANCE_COEFFICIENT}`);
+    assert(game.score > 0, 'score should have advanced over 10 steps');
+  });
+
+  it('migrateScoreScale clears pre-v2 scores exactly once', () => {
+    localStorage.setItem('dino-high-score', '9999');
+    localStorage.setItem('dino-daily-best', '4242');
+    localStorage.removeItem('dino-score-scale');
+    migrateScoreScale();
+    assertEquals(localStorage.getItem('dino-high-score'), null, 'pre-v2 high score cleared');
+    assertEquals(localStorage.getItem('dino-daily-best'), null, 'pre-v2 daily best cleared');
+    assertEquals(localStorage.getItem('dino-score-scale'), 'v2', 'scale marked v2');
+    // second run is a no-op
+    localStorage.setItem('dino-high-score', '50');
+    migrateScoreScale();
+    assertEquals(localStorage.getItem('dino-high-score'), '50', 'already-migrated: no further clearing');
+  });
 });
 
 describe('Obstacle Gap Enforcement', () => {
@@ -355,8 +379,12 @@ describe('Ambient depth + confetti (PR-D)', () => {
     game.state = STATE.RUNNING;
     game.graceFrames = 0;
     // Clear pool and fast-forward to just before a level boundary.
+    // Distance-based scoring: score = distance * DISTANCE_COEFFICIENT.
+    // Set distance so score is just below SCORE_PER_LEVEL; the next tick adds
+    // INITIAL_SPEED to distance and crosses the boundary.
     Particles.reset();
-    game.score = GAME_CONFIG.SCORE_PER_LEVEL - 0.05; // next gameLoop tick crosses
+    game.distance = (GAME_CONFIG.SCORE_PER_LEVEL - 0.05) / GAME_CONFIG.DISTANCE_COEFFICIENT;
+    game.score = game.distance * GAME_CONFIG.DISTANCE_COEFFICIENT; // keep prevLevel consistent
     gameLoop();
     cancelAnimationFrame(game.animationFrameId);
     const live = Particles.particles.filter(p => p.life > 0 && p.color === '#ffd700').length;
@@ -823,6 +851,9 @@ describe('Day/Night Cycle', () => {
     assert(!game.starsInitialised, 'starsInitialised should be false after reset');
     assertEquals(game.stars.length, 0, 'stars should be empty after reset');
 
+    // Distance-based scoring: score = distance * DISTANCE_COEFFICIENT.
+    // Set distance so score is at 400 when handleRunning reads it.
+    game.distance = 400 / GAME_CONFIG.DISTANCE_COEFFICIENT;
     game.score = 400;
     game.state = STATE.RUNNING;
     game.graceFrames = 0;
@@ -846,6 +877,8 @@ describe('High Score', () => {
     game.obstacles.push({ x: 50, y: GAME_CONFIG.CANVAS_H - 40, width: 20, height: 40 });
     game.state = STATE.RUNNING;
     game.graceFrames = 0;
+    // Distance-based scoring: set distance so score computes to 100 after one step.
+    game.distance = 100 / GAME_CONFIG.DISTANCE_COEFFICIENT;
     game.score = 100;
     game.highScore = 50;
 
@@ -1378,7 +1411,10 @@ describe('Death screen', () => {
     const origGraceFrames = game.graceFrames;
 
     game.highScore         = 1000;
-    game.score             = 1200;
+    // Distance-based scoring: score = distance * DISTANCE_COEFFICIENT.
+    // Set distance so that after handleRunning's step, Math.floor(score) = 1200.
+    game.distance          = 1200 / GAME_CONFIG.DISTANCE_COEFFICIENT; // score will be ~1200 after one step
+    game.score             = game.distance * GAME_CONFIG.DISTANCE_COEFFICIENT; // pre-tick score for prevLevel
     game.state             = STATE.RUNNING;
     game.graceFrames       = 0;
     game.lastObstacleX     = canvas.width; // prevent an extra spawn firing


### PR DESCRIPTION
## Summary

Makes the game *move* like the official `chrome://dino`. Diagnosed three compounding causes via evidence (Win32 GPU query → 144 Hz monitor + faithful extraction of Chromium's `offline.js`), then ported the engine to match.

| | Before | After (official) |
|---|---|---|
| Time-stepping | frame-based (assumes 60 Hz) → ran **2.4× too fast on 144 Hz** | **fixed-timestep accumulator** at MS_PER_STEP = 1/60 s |
| `GRAVITY` / `JUMP_POWER` | 0.48 / −12 (floaty 144 px arc) | **0.6 / −10** (snappy 78 px arc) |
| Speed ramp | sigmoid (start 3, plateau 8) | **linear** (start 6, +0.001/step, cap 13) |
| Gap model | fixed-px, *shrinks* with speed | **`width × speed + minGap × 0.6`**, randomized to ×1.5 |
| Scoring | `+0.1`/frame (rate scaled with refresh) | **`distance × 0.025`**, accumulating speed/step |

No new gameplay (no duck, no birds, no sprite work) — pure feel parity. Modes / juice / atmosphere / daily challenge / determinism contract preserved.

## Backward compatibility

The fixed-timestep loop keeps a **no-arg `gameLoop()` single-step path**, so the ~40 existing test blocks that drive frames via `gameLoop()` work unchanged — only assertions whose *numbers* changed were edited (jump apex, gap band, etc.).

## What's in this PR

- **Spec:** `docs/superpowers/specs/2026-05-25-official-feel-parity-design.md`
- **Plan:** `docs/superpowers/plans/2026-05-25-official-feel-parity.md`
- **12 commits**, one per task + targeted review-feedback fixes, all reviewed by spec-compliance + code-quality subagent passes.
- New invariants and `dino-score-scale` localStorage key documented in `CLAUDE.md`; `CONTEXT.md` glossary updated.
- One-time `migrateScoreScale()` clears pre-v2 high scores at first load (the score scale changed; old bests are not comparable).

## Test Plan

- [x] `npm test` — **146/146 passing**.
- [x] Determinism test: 60 Hz and 144 Hz timelines produce the same step count (within ±2).
- [x] Browser smoke-test on running game (Playwright): loop measured at **59.9 steps/sec**, jump launch velocity exactly **−10**, obstacles spawn / collide / death-save high score correctly, migration sets `dino-score-scale: v2`.
- [ ] Reviewer: open the game side-by-side with `chrome://dino` and confirm jump feel + gap spacing match.
- [ ] Reviewer: confirm classic-mode gap *jitter* is desired (this PR removes the old jitter-free carve-out — the official has jitter, so this is more faithful; flagged for explicit awareness).

## Risks

- High score / daily best are reset once on first load of this version. Migration is idempotent and guarded by `dino-score-scale='v2'`. Wrapped in try/catch in case of private-browsing storage errors.
- The classic-mode "no jitter" property is gone (deliberate; matches official). If you'd rather keep it, easy revert: add an `if (mode === 'classic') return minGap;` guard in `computeNextSpawnGap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)